### PR TITLE
Hover talent pill reveals full name + effect (closes #11)

### DIFF
--- a/app.js
+++ b/app.js
@@ -542,7 +542,8 @@ function renderTalentList(t) {
     const meta = state.talents.find(x => x.name === tal.name);
     const isNeg = meta && meta.polarity === 'negative';
     const effect = (meta && meta.effect) ? meta.effect : '';
-    return `<div class="talent-pill ${isNeg?'negative':''}">
+    const tooltip = tal.name + (effect ? '\n' + effect : '');
+    return `<div class="talent-pill ${isNeg?'negative':''}" title="${escapeHtml(tooltip)}">
       <img src="${ICON_DIR}${tal.icon}" alt="${escapeHtml(tal.name)}" onerror="this.style.opacity=0.2">
       <div class="info">
         <div class="name">${escapeHtml(tal.name)}</div>

--- a/app.js
+++ b/app.js
@@ -542,8 +542,7 @@ function renderTalentList(t) {
     const meta = state.talents.find(x => x.name === tal.name);
     const isNeg = meta && meta.polarity === 'negative';
     const effect = (meta && meta.effect) ? meta.effect : '';
-    const tooltip = tal.name + (effect ? '\n' + effect : '');
-    return `<div class="talent-pill ${isNeg?'negative':''}" title="${escapeHtml(tooltip)}">
+    return `<div class="talent-pill ${isNeg?'negative':''}">
       <img src="${ICON_DIR}${tal.icon}" alt="${escapeHtml(tal.name)}" onerror="this.style.opacity=0.2">
       <div class="info">
         <div class="name">${escapeHtml(tal.name)}</div>
@@ -551,6 +550,10 @@ function renderTalentList(t) {
       </div>
       <span class="lvl">${'I'.repeat(tal.level||1)}</span>
       <button class="remove" onclick="rmTalent('${t.id}',${i})" title="Remove">×</button>
+      <div class="talent-tip" role="tooltip">
+        <div class="tip-name">${escapeHtml(tal.name)}</div>
+        ${effect ? `<div class="tip-effect">${escapeHtml(effect)}</div>` : ''}
+      </div>
     </div>`;
   }).join('');
 }

--- a/style.css
+++ b/style.css
@@ -395,6 +395,7 @@ table.roster.editable .row-go:hover {
   display: flex; align-items: center; gap: 8px;
   background: var(--bg3); border: 1px solid var(--border);
   border-radius: 6px; padding: 8px;
+  position: relative;
 }
 .talent-pill img { width: 36px; height: 36px; flex-shrink: 0; background: var(--bg); border-radius: 4px; }
 .talent-pill .info { flex: 1; min-width: 0; }
@@ -411,6 +412,32 @@ table.roster.editable .row-go:hover {
   padding: 2px 6px; font-size: 16px; line-height: 1;
 }
 .talent-pill .remove:hover { color: var(--red); }
+
+.talent-tip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  z-index: 10;
+  width: max-content;
+  max-width: 320px;
+  background: var(--bg2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  box-shadow: var(--shadow);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 60ms ease;
+}
+.talent-pill:hover .talent-tip,
+.talent-pill:focus-within .talent-tip {
+  opacity: 1;
+  visibility: visible;
+}
+.talent-tip .tip-name { font-weight: 700; font-size: 13px; margin-bottom: 4px; }
+.talent-tip .tip-effect { font-size: 12px; color: var(--text-dim); white-space: normal; line-height: 1.35; }
 
 .add-talent-row { display: flex; gap: 6px; margin-top: 8px; align-items: center; }
 .add-talent-row input { flex: 1; }


### PR DESCRIPTION
## Summary
- Talent pill effect text is truncated with ellipsis to keep grid heights consistent. Adds a custom CSS popover (no JS, no native `title`) that appears instantly when the pill is hovered or focused, showing the full **name + effect** in a themed box anchored above the pill.
- Themed via existing `--bg2` / `--border` / `--shadow` vars, so it works in both dark and light modes without any extra theme work.
- `pointer-events: none` on the popover so cursor movement over it never causes flicker.
- Wrapped to 320px max-width so long effects break to multiple lines instead of overflowing the viewport.
- Keyboard accessibility via `:focus-within` (the close button inside the pill is focusable, so tabbing through pills also reveals the popover).

## Test plan
- [x] Verified the popover element renders inside each `.talent-pill` with `.tip-name` + `.tip-effect`
- [x] Verified the previous `title=` attribute is no longer set on the pill
- [x] Verified idle state: `opacity: 0`, `visibility: hidden`
- [x] Verified hover/focus rule `.talent-pill:hover .talent-tip` is present in the stylesheet
- [x] Visual screenshot confirms the popover styling matches a "modal-like" box (themed border, shadow, padding, wrapped text)
- [x] No console errors after navigating to a profile and rendering talents
- [ ] Manual hover check on real hardware in dark + light mode