### PR TITLE
Add missing Hardened Skin — Anti-Blunt talent (closes #12)

### DIFF
--- a/data/talents.json
+++ b/data/talents.json
@@ -396,6 +396,18 @@
     "polarity": "positive"
   },
   {
+    "name": "Hardened Skin — Anti-Blunt",
+    "cn_name": null,
+    "category": "Weapon Damage Talents",
+    "type": "Combat — Damage-type Resist",
+    "effect": "DMG taken from blunt/strike-type attacks −10% / −15% / −20%",
+    "lock": null,
+    "prereq": null,
+    "icon": "tianfu_yingpikangdaji.webp",
+    "icon_url": "https://saraserenity.net/soulmask/img/ng/tianfu_yingpikangdaji.webp",
+    "polarity": "positive"
+  },
+  {
     "name": "Hardened Skin — Anti-Pierce",
     "cn_name": null,
     "category": "Weapon Damage Talents",


### PR DESCRIPTION
Closes #12. Pure data add — the icon \`tianfu_yingpikangdaji.webp\` was already shipping in \`icons/\`, just no JSON entry pointing at it.

## Summary

- Adds \`Hardened Skin — Anti-Blunt\` to \`data/talents.json\` with the same shape as its two siblings (Anti-Pierce, Anti-Slash). Effect text follows the existing pattern: \`DMG taken from blunt/strike-type attacks −10% / −15% / −20%\`.
- Total catalog entries: 252 → 253.

## Test plan

- [x] Reload the app, open a profile, type \"hardened\" in the talent autocomplete — all three siblings appear, including the new Anti-Blunt with its proper icon.
- [x] HEAD-fetched the icon from the dev server: returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)