### PR TITLE
Duplicate tribesman from profile (closes #16)

### DIFF
--- a/app.js
+++ b/app.js
@@ -527,6 +527,7 @@ function renderProfile() {
     <h2>${escapeHtml(t.name)}</h2>
     <span class="meta">LV ${t.level ?? '—'} · ${escapeHtml(t.title || '')} ${escapeHtml(t.profession || '')} · ${escapeHtml(t.tribe || '')} ${t.trait ? '· '+escapeHtml(t.trait) : ''}</span>
     <span class="grow" style="flex:1"></span>
+    <button onclick="onDuplicateTribesman('${t.id}')" title="Create an editable copy with a new id">Duplicate</button>
     <button onclick="onDeleteTribesman('${t.id}')" class="btn-danger-strong">Delete tribesman</button>
   </div>`;
   html += '<div class="profile">';
@@ -1890,6 +1891,30 @@ function addTribesman() {
   renderRoster();
   ui.showProfile(t.id);
 }
+
+// Deep-clone a tribesman with a fresh id. Resets is_body (the body flag is
+// tied to the original character corpse in-game) but keeps talents, skills,
+// weapons, attrs, groups, tags, and notes — that's the whole point of
+// duplication: planning "what if I built another one like this".
+function duplicateTribesman(id) {
+  const src = state.roster.find(t => t.id === id);
+  if (!src) return null;
+  const copy = JSON.parse(JSON.stringify(src));
+  copy.id = newId();
+  copy.name = `${src.name} (copy)`;
+  copy.is_body = false;
+  state.roster.push(copy);
+  saveState();
+  initFilters();
+  return copy;
+}
+
+window.onDuplicateTribesman = function(id) {
+  const copy = duplicateTribesman(id);
+  if (!copy) return;
+  renderRoster();
+  ui.showProfile(copy.id);
+};
 
 // === BIND UI ===
 function bindUI() {


### PR DESCRIPTION
Closes #16. Small self-contained add: a "Duplicate" button in the profile header that deep-clones the current tribesman with a fresh id and lands you on the new profile.

## Summary

- Adds \`duplicateTribesman(id)\` mirroring the existing \`duplicatePlan\` pattern from #18.
- New "Duplicate" button between "Prev/Next" and "Delete tribesman" in the profile header.
- Copy carries: talents, skills, weapons, attrs, groups, tags, notes (everything you'd want when prototyping a "what if I built another one like this").
- Reset on the copy: \`is_body\` (the in-game body-flag doesn't transfer to a planning copy), \`id\` (fresh \`T_\`), \`name\` (suffixed with \` (copy)\`).

## Test plan

- [x] Open Andaria's profile → click Duplicate → roster grows from 25 → 26, lands on "Andaria (copy)" profile, talent count matches the original (5).
- [x] New tribesman has \`is_body: false\` regardless of source's value.
- [x] New id starts with \`T_\` and is distinct from the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)