### PR TITLE
Surface talent info inside plan steps (closes #20)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1713,10 +1713,13 @@ function renderPlanStep(plan, step, index) {
     })).join('');
 
   // Type-specific subject pickers
+  const mentor = step.mentorId ? findTribesman(step.mentorId) : null;
+
   let subject = '';
   if (step.type === 'cap-raise') {
     const ceiling = trainee && step.weapon ? weaponCeiling(trainee.profession, step.weapon) : null;
     const traineeCap = trainee && step.weapon ? (trainee.weapons?.[step.weapon]?.cap ?? '—') : '—';
+    const mentorCap = mentor && step.weapon ? (mentor.weapons?.[step.weapon]?.cap ?? null) : null;
     subject = `<label>Weapon</label>
       <select onchange="stepFieldUpd('${plan.id}','${step.id}','weapon',this.value)">
         <option value="">— pick weapon —</option>
@@ -1726,9 +1729,24 @@ function renderPlanStep(plan, step, index) {
       <input type="number" min="1" max="125" value="${step.targetCap ?? ''}"
         placeholder="${ceiling ?? ''}"
         oninput="stepFieldUpd('${plan.id}','${step.id}','targetCap',this.value)">
-      ${step.weapon ? `<span class="muted small">trainee ${traineeCap} → ceiling ${ceiling}</span>` : ''}`;
+      ${step.weapon ? `<span class="muted small">trainee ${traineeCap} → ceiling ${ceiling}${mentorCap ? ` · mentor ${mentorCap}` : ''}</span>` : ''}`;
   } else if (step.type === 'upgrade') {
     const traineeTalents = (trainee?.talents || []).filter(t => (t.level || 0) < 3);
+    // Show the picked talent's icon + tooltip (with the mentor's level for context)
+    let upgradePreview = '';
+    if (step.talent) {
+      const traineeT = (trainee?.talents || []).find(t => t.name === step.talent);
+      const mentorT = (mentor?.talents || []).find(t => t.name === step.talent);
+      if (traineeT) {
+        const meta = talentMeta(step.talent);
+        const previewTalent = { ...traineeT, icon: traineeT.icon || meta?.icon };
+        const mentorLvl = mentorT ? `mentor Lv ${mentorT.level}` : (mentor ? 'mentor doesn\'t have this talent' : '');
+        upgradePreview = `<div class="plan-step-talent-preview">
+          ${renderTalentIconRow([previewTalent])}
+          <span class="muted small">trainee Lv ${traineeT.level}${mentorLvl ? ' · ' + mentorLvl : ''}</span>
+        </div>`;
+      }
+    }
     subject = `<label>Talent</label>
       <select onchange="stepFieldUpd('${plan.id}','${step.id}','talent',this.value)">
         <option value="">— pick talent —</option>
@@ -1737,9 +1755,33 @@ function renderPlanStep(plan, step, index) {
       <label>Target Lv</label>
       <select onchange="stepFieldUpd('${plan.id}','${step.id}','targetLevel',this.value)">
         ${[2,3].map(lv => `<option value="${lv}" ${lv === step.targetLevel ? 'selected' : ''}>Lv ${lv}</option>`).join('')}
-      </select>`;
+      </select>
+      ${upgradePreview}`;
   } else if (step.type === 'learn') {
-    subject = `<span class="muted small">Random talent (Lv I) drawn from mentor's eligible positive talents.</span>`;
+    // List the actual learnable talents the mentor brings to the table, not
+    // just the static "random talent" placeholder. Without a mentor, fall
+    // back to the placeholder copy.
+    let learnPreview = `<span class="muted small">Random talent (Lv I) drawn from mentor's eligible positive talents.</span>`;
+    if (mentor && trainee) {
+      const knownNames = new Set((trainee.talents || []).map(t => t.name));
+      const eligible = (mentor.talents || []).filter(t => {
+        const meta = talentMeta(t.name);
+        return meta && meta.polarity === 'positive'
+          && !knownNames.has(t.name)
+          && isLearnableBy(t.name, trainee);
+      });
+      if (eligible.length) {
+        // Display level shows the mentor's level (for tooltip context), even
+        // though Learn always lands at Lv I in-game.
+        learnPreview = `<div class="plan-step-talent-preview">
+          ${renderTalentIconRow(eligible)}
+          <span class="muted small">${eligible.length} possible outcome${eligible.length === 1 ? '' : 's'} · all land at Lv I</span>
+        </div>`;
+      } else {
+        learnPreview = `<span class="muted small">${escapeHtml(mentor.name)} has no learnable talents for this trainee.</span>`;
+      }
+    }
+    subject = learnPreview;
   }
 
   const statusBtns = STEP_STATUSES.map(st =>

--- a/style.css
+++ b/style.css
@@ -450,6 +450,13 @@ table.roster.editable .row-go:hover {
 }
 .talent-icon-mini img { width: 100%; height: 100%; object-fit: cover; border-radius: 2px; display: block; }
 .talent-icon-mini.negative { border-color: var(--red); }
+
+/* Talent preview inside a plan step (Learn / Upgrade subject area) */
+.plan-step-talent-preview {
+  display: flex; flex-wrap: wrap; gap: 8px; align-items: center;
+  margin-top: 4px; flex-basis: 100%;
+}
+.plan-step-talent-preview .talent-icon-mini { width: 26px; height: 26px; }
 .talent-tip .tip-name { font-weight: 700; font-size: 13px; margin-bottom: 4px; }
 .talent-tip .tip-effect { font-size: 12px; color: var(--text-dim); white-space: normal; line-height: 1.35; }
 


### PR DESCRIPTION
Closes #20. Plan editor was opaque about which talents a Learn step would actually pick from once a mentor was selected; this PR makes the candidate list visible.

## Summary

- **Learn step:** when a mentor is set, list the eligible talents (positive, learnable, not already on the trainee) as a row of icons with hover tooltips, plus an \"N possible outcomes · all land at Lv I\" caption. Falls back to \"\\\${mentor name} has no learnable talents for this trainee\" when the intersection is empty.
- **Upgrade step:** when a talent is picked, show the talent's icon next to the dropdowns with the tooltip from the catalog, plus a context line — \`trainee Lv 2 · mentor Lv 3\`.
- **Cap-raise step:** the existing \`trainee 99 → ceiling 100\` caption now also surfaces the selected mentor's cap on that weapon.
- Reuses \`renderTalentIconRow\` from #26 so the icon + tooltip behavior matches the roster column. New \`.plan-step-talent-preview\` class sizes the icons slightly larger (26px vs 22px) since they're the focal piece of the step card.

## Test plan

- [x] Build a plan with one of each step type, mentors set: Learn shows N icons matching the mentor's eligible-talent count; Upgrade shows the picked talent's icon + level context; Cap-raise caption includes mentor's cap.
- [x] Hover an icon → name + Lv + effect tooltip appears (reused styling).
- [x] Mentor swap re-renders the eligible list.
- [x] When no mentor is picked yet, Learn falls back to the original placeholder copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)