### PR TITLE
Suggest plan button materializes Training Suggestions (closes #21)

### DIFF
--- a/app.js
+++ b/app.js
@@ -527,6 +527,7 @@ function renderProfile() {
     <h2>${escapeHtml(t.name)}</h2>
     <span class="meta">LV ${t.level ?? '—'} · ${escapeHtml(t.title || '')} ${escapeHtml(t.profession || '')} · ${escapeHtml(t.tribe || '')} ${t.trait ? '· '+escapeHtml(t.trait) : ''}</span>
     <span class="grow" style="flex:1"></span>
+    <button onclick="onSuggestPlan('${t.id}')" title="Build a draft plan from this tribesman's Training Suggestions">Suggest plan</button>
     <button onclick="onDuplicateTribesman('${t.id}')" title="Create an editable copy with a new id">Duplicate</button>
     <button onclick="onDeleteTribesman('${t.id}')" class="btn-danger-strong">Delete tribesman</button>
   </div>`;
@@ -1469,6 +1470,47 @@ function suggestionToStep(suggestion) {
   // 'learn' has no extra fields beyond mentor (random outcome in-game)
   return step;
 }
+
+// One-click materialize the trainee's Training Suggestions into a draft
+// plan. Ordering rationale (per #21): cap raises gate weapon power and so
+// front-load the most leverage, learns broaden the talent pool, upgrades
+// polish what's already there. Capped at 5 steps so the plan stays
+// scannable; user can extend manually.
+const SUGGEST_PLAN_STEP_BUDGET = 5;
+
+function suggestPlanFor(traineeId) {
+  const trainee = findTribesman(traineeId);
+  if (!trainee) return null;
+  const suggestions = getTrainingSuggestions(trainee);
+  if (!suggestions.length) return null;
+
+  // Sort cap-raises by gap descending (biggest improvement first); learns
+  // and upgrades retain their natural order from getTrainingSuggestions.
+  const capRaises = suggestions
+    .filter(s => s.type === 'cap-raise')
+    .slice()
+    .sort((a, b) => (b.targetCap - b.currentCap) - (a.targetCap - a.currentCap));
+  const learns = suggestions.filter(s => s.type === 'learn');
+  const upgrades = suggestions.filter(s => s.type === 'upgrade');
+  const ordered = [...capRaises, ...learns, ...upgrades].slice(0, SUGGEST_PLAN_STEP_BUDGET);
+
+  const plan = createPlan(traineeId, `${trainee.name} — suggested plan`);
+  for (const s of ordered) plan.steps.push(suggestionToStep(s));
+  saveState();
+  return plan;
+}
+
+window.onSuggestPlan = function(traineeId) {
+  const trainee = findTribesman(traineeId);
+  if (!trainee) return;
+  const suggestions = getTrainingSuggestions(trainee);
+  if (!suggestions.length) {
+    alert(`No training opportunities found for ${trainee.name} in the current roster.`);
+    return;
+  }
+  const plan = suggestPlanFor(traineeId);
+  if (plan) ui.showPlan(plan.id);
+};
 
 // Picker dialog: "add to existing plan" or "start a new plan". Renders into
 // the existing modal scaffolding (#modal-bg / #modal). Plain DOM, no framework.


### PR DESCRIPTION
Closes #21. The structured \`getTrainingSuggestions\` from #19 was specifically built to enable this; this PR turns it on.

## Summary

A new **Suggest plan** button in the profile header (between "+ Next" and "Duplicate"). One click materializes the trainee's full Training Suggestions list into a draft \`TrainingPlan\`, skipping the per-suggestion modal cycle.

Ordering matches the spec verbatim:

1. **Cap raises first**, sorted by gap descending (biggest cap improvement at the top of the queue).
2. **Learn next** — the lumped "could learn N more talents" suggestion becomes one Learn step with the top mentor pre-selected.
3. **Upgrades last** — one step per upgradable talent.
4. **Capped at 5 steps** so the plan stays readable; user can extend manually.
5. **Status: draft** — the user lands on the editor with everything pre-filled and editable before they commit.

Falls back to a helpful \`alert()\` when the trainee has no opportunities at all (e.g. fully-capped late-game tribesman with maxed talents).

## Test plan

- [x] Andaria (lots of low caps) → 5 cap-raise steps, ordered by gap.
- [x] Atalanta (only 1 learn opportunity) → 1-step plan, learn type.
- [x] Stevie (mix of all three types, 11 total suggestions) → 5-step plan, cap raises first per the impact ordering.
- [x] Each generated step has a sensible mentor pre-selected (top candidate from the suggestion's \`mentorIds\`) and the type-appropriate fields filled in (weapon + targetCap, or talent + targetLevel).
- [x] Land on plan editor immediately after generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)