### PR TITLE
Flag suggestions already covered by an active plan (closes #32)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1103,16 +1103,55 @@ function getTrainingSuggestions(trainee) {
   return out;
 }
 
+// Returns the list of draft/active plans whose steps already cover this
+// suggestion. Match rules per step type:
+//   cap-raise: same trainee + step.weapon === suggestion.weapon
+//   upgrade:   same trainee + step.talent === suggestion.talent
+//   learn:     same trainee + any learn step at all (Learn is random in-game,
+//              so a queued Learn session is a queued Learn session — we can't
+//              be more specific without modeling outcome targeting).
+// Excludes steps already completed/abandoned: they're done work.
+/**
+ * @param {Tribesman} trainee
+ * @param {TrainingSuggestion} suggestion
+ * @returns {TrainingPlan[]}
+ */
+function plansContainingSuggestion(trainee, suggestion) {
+  return state.plans.filter(p => {
+    if (p.traineeId !== trainee.id) return false;
+    if (p.status !== 'draft' && p.status !== 'active') return false;
+    return p.steps.some(s => {
+      if (s.status === 'completed' || s.status === 'abandoned') return false;
+      if (s.type !== suggestion.type) return false;
+      if (s.type === 'cap-raise') return s.weapon === suggestion.weapon;
+      if (s.type === 'upgrade')   return s.talent === suggestion.talent;
+      if (s.type === 'learn')     return true; // any learn step counts
+      return false;
+    });
+  });
+}
+
 function renderTrainingSuggestions(trainee) {
   const suggestions = getTrainingSuggestions(trainee);
   if (!suggestions.length) {
     return '<p class="muted">No training opportunities found in current roster.</p>';
   }
-  return suggestions.map((s, i) => `<div class="suggestion">
-    <div class="head">${s.head}</div>
-    <div class="why">${s.why}</div>
-    <button class="small suggestion-add" onclick="onAddSuggestionToPlan('${trainee.id}', ${i})">+ Add to plan</button>
-  </div>`).join('');
+  return suggestions.map((s, i) => {
+    const inPlans = plansContainingSuggestion(trainee, s);
+    let badge = '';
+    if (inPlans.length === 1) {
+      const p = inPlans[0];
+      badge = `<a class="suggestion-in-plan" href="javascript:void(0)" onclick="ui.showPlan('${p.id}')" title="Open plan">✓ in plan: ${escapeHtml(p.name || 'Untitled')}</a>`;
+    } else if (inPlans.length > 1) {
+      badge = `<span class="suggestion-in-plan" title="${escapeHtml(inPlans.map(p => p.name || 'Untitled').join(', '))}">✓ in ${inPlans.length} plans</span>`;
+    }
+    return `<div class="suggestion${inPlans.length ? ' is-planned' : ''}">
+      <div class="head">${s.head}</div>
+      <div class="why">${s.why}</div>
+      ${badge}
+      <button class="small suggestion-add" onclick="onAddSuggestionToPlan('${trainee.id}', ${i})">+ Add to plan</button>
+    </div>`;
+  }).join('');
 }
 
 // === IMPORT / EXPORT ===

--- a/style.css
+++ b/style.css
@@ -786,6 +786,23 @@ button[disabled] { opacity: 0.4; cursor: not-allowed; }
 }
 .suggestion .suggestion-add:hover { background: var(--accent); color: var(--accent-on); }
 
+/* "✓ in plan: <name>" badge — shown when this suggestion is already a step
+   in one of the trainee's draft/active plans (#32). Sits next to the
+   + Add to plan button so the duplicate-plan signal is visible at a glance. */
+.suggestion .suggestion-in-plan {
+  display: inline-block;
+  margin-top: 6px; margin-right: 8px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--row-hover);
+  color: var(--tier-iron);
+  border: 1px solid var(--tier-iron);
+  font-size: 11px;
+  text-decoration: none;
+}
+a.suggestion-in-plan:hover { filter: brightness(1.15); text-decoration: underline; }
+.suggestion.is-planned { opacity: 0.85; }
+
 /* Profile-side Plans card */
 .profile-plans-warning {
   background: var(--row-hover); border-left: 3px solid var(--tier-specialist);


### PR DESCRIPTION
Closes #32. Each Training Suggestion now shows whether it's already represented as a step in one of the trainee's draft/active plans.

## Summary

- New \`plansContainingSuggestion(trainee, suggestion)\` helper that returns the trainee's plans whose live steps cover the suggestion.
- Match rules per type:
  - **cap-raise**: same weapon as the suggestion
  - **upgrade**: same talent
  - **learn**: any non-completed Learn step (Learn is random in-game — can't match more specifically without modeling outcome targeting)
  - Already-completed / abandoned steps are excluded.
- Matching suggestions render with a \`.is-planned\` modifier (light opacity dim) plus an "✓ in plan: <name>" badge. Single match → clickable link to the plan editor. Multiple matches → "✓ in N plans" with a hover-title listing all of them.
- The "+ Add to plan" button stays usable — duplicate planning is sometimes intentional (e.g. two phases of the same training agenda).

## Test plan

- [x] Build a plan with a cap-raise step on Spear and an upgrade step on a known talent → matching suggestions get the badge; the learn suggestion stays unflagged.
- [x] Click the badge → lands on the plan editor.
- [x] Two plans both targeting the same upgrade → badge reads "✓ in 2 plans".
- [x] Mark a step \`completed\` → the corresponding suggestion drops the badge (not blocking re-suggestion of done work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)