### PR TITLE
Roster combat skills + groups/tags inline-editable (closes #34)

### DIFF
--- a/app.js
+++ b/app.js
@@ -519,15 +519,17 @@ function renderRoster() {
     }
     const classW = PROF_CLASS_WEAPONS[t.profession] || [];
     for (const w of WEAPONS) {
-      const v = (t.weapons?.[w]) || {cap:null};
+      const v = (t.weapons?.[w]) || {current:null, cap:null};
       const cls = tierClass(v.cap);
       const al = classW.includes(w) ? ' aligned-skill' : '';
-      html += `<td class="weapon-cell ${cls}${al}">
-        <input class="cell-input num-tiny" type="number" value="${v.cap ?? ''}" oninput="updWeaponFromRoster('${id}','${w}',this)">
-      </td>`;
+      html += `<td class="weapon-cell ${cls}${al}"><div class="cur-cap">
+        <input class="cell-input num-tiny" type="number" value="${v.current ?? ''}" oninput="updWeaponFromRoster('${id}','${w}','current',this)">
+        <span class="sep">/</span>
+        <input class="cell-input num-tiny" type="number" value="${v.cap ?? ''}" oninput="updWeaponFromRoster('${id}','${w}','cap',this)">
+      </div></td>`;
     }
-    html += `<td>${(t.groups || []).map(g => `<span class="chip group">${escapeHtml(g)}</span>`).join('')}</td>`;
-    html += `<td>${(t.tags || []).map(g => `<span class="chip tag">${escapeHtml(g)}</span>`).join('')}</td>`;
+    html += `<td><input class="cell-input list-input" value="${escapeHtml((t.groups || []).join(', '))}" placeholder="comma-separated" oninput="updListFromRoster('${id}','groups',this.value)" title="Comma-separated. Edit here, or use the profile for chip-style management."></td>`;
+    html += `<td><input class="cell-input list-input" value="${escapeHtml((t.tags || []).join(', '))}" placeholder="comma-separated" oninput="updListFromRoster('${id}','tags',this.value)" title="Comma-separated. Edit here, or use the profile for chip-style management."></td>`;
     html += `<td>${renderTalentIconRow(t.talents)}</td>`;
     html += '</tr>';
   }
@@ -905,22 +907,48 @@ function updSkillFromRoster(id, skill, field, inputEl) {
   }
 }
 
-function updWeaponFromRoster(id, weapon, inputEl) {
+function updWeaponFromRoster(id, weapon, field, inputEl) {
   const t = state.roster.find(x => x.id === id);
   if (!t) return;
   t.weapons = t.weapons || {};
   t.weapons[weapon] = t.weapons[weapon] || {current:null, cap:null};
   const val = inputEl.value === '' ? null : +inputEl.value;
-  t.weapons[weapon].cap = val;
+  t.weapons[weapon][field] = val;
   saveState();
-  const td = inputEl.closest('td');
-  if (td) {
-    const aligned = (PROF_CLASS_WEAPONS[t.profession] || []).includes(weapon);
-    td.className = `weapon-cell ${tierClass(val)}${aligned ? ' aligned-skill' : ''}`;
+  if (field === 'cap') {
+    const td = inputEl.closest('td');
+    if (td) {
+      const aligned = (PROF_CLASS_WEAPONS[t.profession] || []).includes(weapon);
+      td.className = `weapon-cell ${tierClass(val)}${aligned ? ' aligned-skill' : ''}`;
+    }
   }
 }
+
+// Comma-separated inline editor for groups/tags. The profile keeps its
+// chip+button rich UI; this is the dense-grid alternative.
+function updListFromRoster(id, listKey, csv) {
+  const t = state.roster.find(x => x.id === id);
+  if (!t) return;
+  // Parse: split on commas, trim, drop empties, dedupe (case-insensitive).
+  const seen = new Set();
+  const items = csv.split(',').map(s => s.trim()).filter(s => {
+    if (!s) return false;
+    const k = s.toLowerCase();
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+  t[listKey] = items;
+  saveState();
+  // Refresh the relevant filter dropdown so newly-typed groups/tags appear in
+  // the toolbar without a full re-render of the table (which would steal focus
+  // from the input the user is still editing).
+  initFilters();
+}
+
 window.updSkillFromRoster = updSkillFromRoster;
 window.updWeaponFromRoster = updWeaponFromRoster;
+window.updListFromRoster = updListFromRoster;
 
 function addToList(id, listKey) {
   const t = state.roster.find(x => x.id === id);

--- a/style.css
+++ b/style.css
@@ -248,6 +248,13 @@ table.roster.editable input.cell-input.num-tiny {
   font-variant-numeric: tabular-nums;
   color: inherit;
 }
+table.roster.editable input.cell-input.list-input {
+  min-width: 120px;
+  color: var(--accent);
+}
+table.roster.editable input.cell-input.list-input::placeholder {
+  color: var(--text-dim); opacity: 0.6;
+}
 /* MozAppearance / WebkitAppearance: hide spinners to save horizontal space */
 table.roster.editable input.cell-input.num-tiny::-webkit-outer-spin-button,
 table.roster.editable input.cell-input.num-tiny::-webkit-inner-spin-button {


### PR DESCRIPTION
Closes #34. Two ergonomic fixes for the roster grid that were called out as inconsistencies with how crafting/gathering skills already work.

## Summary

- **Combat (weapon) cells now show \`current / cap\`** instead of just \`cap\`, matching how crafting and gathering skills render. \`updWeaponFromRoster\` gains a \`field\` param to handle either.
- **Groups and Tags** are now inline-editable as comma-separated text inputs. Typing into the cell updates state immediately (parse → trim → dedupe case-insensitively). The profile keeps its richer chip+button management for adding from existing options — that's still the better surface for browsing what other tribesmen have.
- After an inline list edit, \`initFilters()\` refreshes the toolbar filter dropdowns so newly-typed groups/tags appear there without a full table re-render (which would steal focus mid-typing).

## Test plan

- [x] Edit Bow current on Andaria's row inline → \`state.roster[Andaria].weapons.Bow.current\` updates; cap unchanged.
- [x] Type "Run Amok, Smelters, Run Amok" into the Groups cell → state holds \`["Run Amok", "Smelters"]\` (whitespace trimmed, duplicates merged).
- [x] Filter dropdown for Groups picks up the new entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)