### PR TITLE
Retire git tags + GitHub Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to **Soulmask Clan Manager** are listed here. Versions
 follow loose semver: a major feature ships as a minor bump (`0.5.0`), small
 fixes/polish stack as patch bumps (`0.5.1`).
 
+There are no git tags or GitHub Releases — the app iterates via PRs against
+`main` and deploys straight from `main` via GitHub Pages. \`APP_VERSION\` in
+`app.js` is the running number (visible in the footer, used as the cache-bust
+query string for the script/style refs, and auto-filled in bug reports).
+
 The live app is at <https://emmyallears.github.io/soulmask-clan-manager/>.
 
 ---

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ runs anywhere — locally, on GitHub Pages, or any static host.
 
 **Live site:** <https://emmyallears.github.io/soulmask-clan-manager/>
 
-> v0.0.1 — first cut, generated with Claude Cowork. Expect rough edges; please open
-> issues at <https://github.com/EmmyAllEars/soulmask-clan-manager/issues>.
+> See [CHANGELOG.md](./CHANGELOG.md) for release notes. The app is iterated
+> via individual PRs against `main`; there's no tag/release ceremony — the
+> footer's version label is the running number.
+> Issues: <https://github.com/EmmyAllEars/soulmask-clan-manager/issues>.
 
 ## Features
 


### PR DESCRIPTION
Tag/release ceremony was stale — nothing tagged after \`v0.4.1\` (the day this project began), and CHANGELOG.md now covers the v0.5.0+ era inline. This PR closes the books on the system.

## What I already did (outside the PR)

- \`gh release delete v0.0.1 v0.0.2 v0.1.0 v0.2.0 v0.3.0 v0.4.0 v0.4.1 --cleanup-tag --yes\` — both the GitHub Releases and their remote git tags are gone.

## What's in the diff

- **CHANGELOG.md** preamble now spells out the convention: PRs against \`main\` are the unit of release; \`APP_VERSION\` in \`app.js\` is the running number (footer + \`?v=\` cache-bust + bug-report auto-fill).
- **README.md** no longer references a stale "v0.0.1 first cut" line; points at CHANGELOG.md.

## What's left untouched

\`APP_VERSION\` stays — it's earning its keep as the cache-bust query string on the script/CSS refs and as the version label in the footer + auto-filled bug reports. Just no more tag-and-release ceremony tied to it.

If a future milestone ever warrants a real downloadable release, tagging is one \`gh release create\` away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)