### PR TITLE
Roster importer: refresh from live server (RCON + screenshots)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ ClanManager/
 │   ├── talents.json        # 252 talents catalog (parsed from TALENTS_REFERENCE.md)
 │   └── default_roster.json # 25-tribesman starter roster
 ├── icons/                  # 251 talent icon WebP files
+├── tools/
+│   └── import-world-db/    # Node CLI: refresh roster from a live Soulmask server (RCON)
 └── README.md               # this file
 ```
 
@@ -108,6 +110,24 @@ groups, tags, talents
 When you Import CSV, the same format is expected. Rows missing fields use defaults.
 **Import REPLACES the entire roster.** Use JSON Backup before importing if you want
 to be safe.
+
+### Importing from a live Soulmask server
+
+If your server is hosted on BisectHosting (or any Pterodactyl-style panel with
+the [Bisect Starbase MCP](https://github.com/EmmyAllEars/BisectHosting-Starbase-MCP)
+configured), there is a Node CLI under [`tools/import-world-db/`](tools/import-world-db/)
+that:
+
+- pulls the current clan roster from the game's RCON (`lgo <guild_uid>`),
+- merges it with your existing `clan_backup.json` — preserving every curated
+  field on tribesmen you've already keyed in,
+- adds blank skeletons for new captures,
+- optionally bumps weapon caps and talent levels using a copy-paste of the
+  in-game **Training ground** log,
+- writes a new `clan_backup.json` you load via the **Restore JSON** button.
+
+See [`tools/import-world-db/README.md`](tools/import-world-db/README.md) for
+the full workflow. No `npm install` — plain Node 18+.
 
 ## Mechanics references baked into the app
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ runs anywhere — locally, on GitHub Pages, or any static host.
 ## Features
 
 - **Roster view** — full table of every tribesman with all 14 work skills + 9 weapon caps
-  + 5 attributes + Recognition. Profession-aligned skills bolded with a star. Cap-tier
+  + 5 attributes. Profession-aligned skills bolded with a star. Cap-tier
   color coded: orange (mastery 120+) → yellow (specialist 100+) → green (Iron 90+) →
   grey (sub-Iron).
 - **Profile view** — full editor for one tribesman: identity, attributes, every skill
@@ -95,7 +95,7 @@ In a tribesman's profile, the "Training Suggestions" card automatically lists:
 When you Export CSV, the columns are:
 
 ```
-id, name, level, title, profession, tribe, trait, location, is_body, recognition, notes,
+id, name, level, title, profession, tribe, trait, location, is_body, notes,
 skill_<Skill>_cur, skill_<Skill>_cap (×14),
 weapon_<Weapon>_cur, weapon_<Weapon>_cap (×9),
 attr_Per, attr_Agi, attr_Phy, attr_End, attr_Str,

--- a/data/default_roster.json
+++ b/data/default_roster.json
@@ -113,7 +113,6 @@
         "End": 16,
         "Str": 17
       },
-      "recognition": "",
       "talents": [
         {
           "name": "Light Footsteps",
@@ -255,7 +254,6 @@
         "End": 14,
         "Str": 13
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Go for the Jugular",
@@ -385,7 +383,6 @@
         "End": null,
         "Str": null
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Body-Resilience Conversion",
@@ -524,7 +521,6 @@
         "End": null,
         "Str": null
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Last Light Counter",
@@ -673,7 +669,6 @@
         "End": null,
         "Str": null
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Last Radiance",
@@ -805,7 +800,6 @@
         "End": 21,
         "Str": 21
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Accelerate Cooking — [Craftsman Exclusive]",
@@ -952,7 +946,6 @@
         "End": null,
         "Str": null
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Extraordinary Talent",
@@ -1084,7 +1077,6 @@
         "End": null,
         "Str": null
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Accelerate Leatherworking — [Porter Exclusive]",
@@ -1226,7 +1218,6 @@
         "End": null,
         "Str": null
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Acceleration at Stress",
@@ -1373,7 +1364,6 @@
         "End": null,
         "Str": null
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Unnoticeable",
@@ -1530,7 +1520,6 @@
         "End": null,
         "Str": null
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Superarmor Break",
@@ -1672,7 +1661,6 @@
         "End": 25,
         "Str": 23
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Swift Pace",
@@ -1809,7 +1797,6 @@
         "End": null,
         "Str": null
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Wild Nature Awakened",
@@ -1956,7 +1943,6 @@
         "End": 13,
         "Str": 16
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Full Stamina",
@@ -2088,7 +2074,6 @@
         "End": 26,
         "Str": 23
       },
-      "recognition": "535 / 1000",
       "talents": [
         {
           "name": "Dual-blade DMG Increase",
@@ -2239,7 +2224,6 @@
         "End": 7,
         "Str": 14
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Grapple-Throw",
@@ -2368,7 +2352,6 @@
         "End": 22,
         "Str": 24
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Crave for Blood",
@@ -2515,7 +2498,6 @@
         "End": 18,
         "Str": 18
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Fire Deterrence",
@@ -2647,7 +2629,6 @@
         "End": 18,
         "Str": 26
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Blood Activating",
@@ -2789,7 +2770,6 @@
         "End": 21,
         "Str": 11
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Rampage",
@@ -2938,7 +2918,6 @@
         "End": 23,
         "Str": 21
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Baffle Reflect",
@@ -3085,7 +3064,6 @@
         "End": 29,
         "Str": 22
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Resourceful",
@@ -3232,7 +3210,6 @@
         "End": 15,
         "Str": 35
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Remote Strike",
@@ -3379,7 +3356,6 @@
         "End": 26,
         "Str": 28
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Trick Force",
@@ -3526,7 +3502,6 @@
         "End": 19,
         "Str": 20
       },
-      "recognition": null,
       "talents": [
         {
           "name": "Fierce Attack",

--- a/tools/import-world-db/EXTRACT_PROMPT.md
+++ b/tools/import-world-db/EXTRACT_PROMPT.md
@@ -1,0 +1,171 @@
+# Screenshot extraction prompt — for any Claude session
+
+Paste the contents of this file as the first message of a Claude session, then
+attach screenshots of one or more tribesmen's **Character → Ability** and
+**Character → Proficiency** tabs. Claude will respond with a single
+`clan-screenshot-patch-v1` JSON document you save to a file and feed to
+`apply-patch.js`.
+
+> **Why a separate prompt instead of embedding it in the CLI:** vision is
+> Claude's job, not Node's. Keeping the extraction in a Claude session means
+> it works in any environment with Claude available, doesn't require an API
+> key in the CLI, and you can interactively correct mistakes before
+> committing the patch.
+
+---
+
+## Prompt to paste
+
+You are extracting structured data from screenshots of the survival game
+**Soulmask**. Each tribesman in the user's clan is captured across two
+screenshots:
+
+- **Character → Ability** tab: shows the tribesman's name (top-left, with a
+  `<E>` / `<Q>` etc. owner-suffix tag), title + profession line (e.g.
+  "Skilled Warrior"), tribe in `<...Tribe>` brackets, "Body N" line,
+  Level (e.g. 50), and the five attributes on a star: **Perception,
+  Agility, Physique, Endurance, Strength**. Ignore the Recognition number —
+  it changes too quickly to be worth tracking and is not part of the
+  output schema.
+
+- **Character → Proficiency** tab: shows two columns — **Production
+  Crafting** and **Combat Skills** — with a `current/cap` value next to each
+  row.
+
+Your job is to emit a single JSON document with this exact schema:
+
+```json
+{
+  "schema": "clan-screenshot-patch-v1",
+  "extractedAt": "<ISO 8601 UTC timestamp of when you produced the patch>",
+  "source": "in-game Character → Ability + Proficiency tabs",
+  "tribesmen": [
+    {
+      "match": { "name": "<name without the <E>/<Q> suffix>" },
+      "level": <int>,
+      "title": "<first word of the title-profession line>",
+      "profession": "<second word — must be one of: Craftsman | Porter | Laborer | Warrior | Hunter | Guard>",
+      "tribe": "<the word inside <...Tribe>; just 'Wildwolf' for '<Wildwolf Tribe>'>",
+      "attrs": { "Per": <int>, "Agi": <int>, "Phy": <int>, "End": <int>, "Str": <int> },
+      "skills": {
+        "<ClanManager skill name>": { "current": <int>, "cap": <int> },
+        ...
+      },
+      "weapons": {
+        "<weapon name>": { "current": <int>, "cap": <int> },
+        ...
+      }
+    }
+  ]
+}
+```
+
+### Skill name mapping (in-game name → ClanManager name)
+
+The Production Crafting tab uses *activity* names; ClanManager uses *worker*
+names. Translate every entry through this table:
+
+| In-game             | ClanManager   |
+| ------------------- | ------------- |
+| Logging             | Lumberjack    |
+| Mining              | Miner         |
+| Harvest             | Gatherer      |
+| Plant               | Farmer        |
+| Weaving             | Weaver        |
+| Potting             | Potter        |
+| Wood & Stone        | Carpenter     |
+| Leatherworking      | Tanner        |
+| Kiln                | Kiln Worker   |
+| Craftsman           | Craftsman     |
+| Alchemy             | Alchemist     |
+| Cooking             | Cook          |
+| Weapon Crafting     | Blacksmith    |
+| Armor Crafting      | Armorer       |
+
+### Weapon names
+
+The Combat Skills tab names already match ClanManager exactly. Use them as-is:
+
+`Spear`, `Shield`, `Dual-blade`, `Great Sword`, `Spiked Whip`, `Blade`,
+`Bow`, `Gauntlets`, `Hammer`.
+
+### Rules
+
+1. **Strip owner-suffix tags** (`<E>`, `<Q>`, etc.) from the name before
+   putting it in `match.name`.
+2. **Title vs profession**: the line just under the name is e.g. "Skilled
+   Warrior". Split on whitespace: first word = `title`, second = `profession`.
+   Validate the second word is one of the six professions; if not, leave
+   `profession` empty and put the whole string in `title`.
+3. **Tribe**: from `<Wildwolf Tribe>`, emit just `"Wildwolf"`.
+4. **If a screenshot is unreadable** for a particular field, omit that field
+   from the patch. Don't guess. The `apply-patch.js` tool preserves existing
+   values for any field absent from the patch.
+5. **Body N / "Body Two" / etc.**: ignore — that's an in-game body-slot
+   indicator, not stored in ClanManager.
+6. **Multiple tribesmen**: append additional entries to the `tribesmen`
+   array. Each tribesman should have both screenshots.
+7. **Innate Talents** (the icon strip at the bottom of the Ability tab):
+   ignore for this patch. Talents are managed manually via the ClanManager
+   UI; the tool will not touch them.
+
+### Output
+
+Reply with **only the JSON document**, no explanatory prose, in a single
+fenced code block. The user will save it to a file and run:
+
+```sh
+node apply-patch.js --patch <file> --existing <clan_backup.json> --out <new>
+```
+
+---
+
+## Reference example (Andaria)
+
+For the test clan, here's a complete patch entry. Use this exact shape and
+field ordering when emitting a real patch.
+
+```json
+{
+  "schema": "clan-screenshot-patch-v1",
+  "extractedAt": "2026-04-28T18:10:00Z",
+  "source": "in-game Character → Ability + Proficiency tabs",
+  "tribesmen": [
+    {
+      "match": { "name": "Andaria" },
+      "level": 50,
+      "title": "Skilled",
+      "profession": "Warrior",
+      "tribe": "Wildwolf",
+      "attrs": { "Per": 23, "Agi": 29, "Phy": 27, "End": 26, "Str": 23 },
+      "skills": {
+        "Lumberjack":  { "current": 21, "cap": 84 },
+        "Miner":       { "current": 30, "cap": 89 },
+        "Gatherer":    { "current": 19, "cap": 91 },
+        "Farmer":      { "current": 19, "cap": 84 },
+        "Weaver":      { "current": 16, "cap": 94 },
+        "Potter":      { "current": 16, "cap": 93 },
+        "Carpenter":   { "current": 48, "cap": 80 },
+        "Tanner":      { "current": 20, "cap": 89 },
+        "Kiln Worker": { "current": 21, "cap": 79 },
+        "Craftsman":   { "current": 14, "cap": 77 },
+        "Alchemist":   { "current": 41, "cap": 84 },
+        "Cook":        { "current": 18, "cap": 79 },
+        "Blacksmith":  { "current": 41, "cap": 88 },
+        "Armorer":     { "current": 20, "cap": 76 }
+      },
+      "weapons": {
+        "Spear":       { "current": 11,  "cap": 99 },
+        "Blade":       { "current": 34,  "cap": 117 },
+        "Shield":      { "current": 21,  "cap": 92 },
+        "Bow":         { "current": 45,  "cap": 99 },
+        "Dual-blade":  { "current": 115, "cap": 115 },
+        "Gauntlets":   { "current": 47,  "cap": 100 },
+        "Great Sword": { "current": 43,  "cap": 115 },
+        "Hammer":      { "current": 38,  "cap": 117 },
+        "Spiked Whip": { "current": 13,  "cap": 75 }
+      }
+    }
+  ]
+}
+```

--- a/tools/import-world-db/README.md
+++ b/tools/import-world-db/README.md
@@ -1,0 +1,216 @@
+# import-world-db — refresh ClanManager from a live Soulmask server
+
+A standalone Node CLI that takes the output of two Soulmask RCON commands plus
+your existing `clan_backup.json` and produces an updated `clan_backup.json`
+that:
+
+- adds new captures (tribesmen present in the game but missing from your
+  roster) as blank skeletons;
+- preserves every curated field on existing tribesmen (skills, talents,
+  attrs, notes, location, etc.);
+- optionally bumps weapon proficiency caps and talent levels using a
+  copy-paste of the in-game **Training ground** log;
+- flags roster entries that no longer appear in the clan as `is_body: true`
+  (configurable; assumes "absent from clan" means "died and was burnt").
+
+The output drops directly into ClanManager's existing **Restore JSON** flow
+(`app.js:1313-1348`). No app changes required.
+
+## Why the name `import-world-db`
+
+The original plan was to read `world.db` (the server's SQLite save) directly
+and parse out captures. That hit two walls:
+
+1. The interesting data lives in a UE-PropertyTag-serialized BLOB (`actor_data`)
+   with Pinyin field names. The Soulmask community has tried and largely
+   failed to parse it.
+2. Even with the BLOB, ownership isn't expressed cleanly — wild NPCs and
+   captured ones share the same blueprint class and the same SQL columns.
+
+The path that actually worked is the game's own RCON output. We kept the
+folder name because the (still-useful) Bisect MCP `get_file_download_url` tool
+was developed alongside it, and `schema.md` documents the discovery findings
+in case someone returns to the BLOB-parser idea.
+
+## Setup (no install needed)
+
+The CLI is plain Node — uses the standard library only. No `npm install`.
+
+```sh
+cd tools/import-world-db
+node cli.js --help
+```
+
+Requires Node 18+. Tested on Node 22.
+
+## End-to-end workflow
+
+You'll need three text files: an `lgo` dump, your current `clan_backup.json`,
+and (optionally) a copy-paste of the in-game training log.
+
+### 1. Capture the clan roster via RCON (~30 seconds)
+
+In a Claude session with the [Bisect Hosting Starbase MCP](https://github.com/EmmyAllEars/BisectHosting-Starbase-MCP)
+configured, ask Claude to:
+
+```
+1. Call mcp__Bisect_Hosting_Starbase__send_command with command="lg" to get the guild UID.
+2. Call send_command with command="lgo <guild_uid>".
+3. Wait ~3 seconds.
+4. Call send_command with command="n" to get page 2 (server retains pagination state per source IP for a few seconds).
+5. read_file /WS/Saved/Logs/WS.log tail_bytes=30000.
+6. Extract the two RESPONSE: blocks and concatenate them into a single text file.
+```
+
+The result is a text dump where each tribesman / vehicle / animal row looks like:
+
+```
+|             'Andaria <E>' | AD41LS8M7FDBQV6IHZX9G9NGU |
+|       'Craftsman M 1 <Q>' | CEFCV8PYUSZZQHAE5EUFGMQ76 |
+|     'Belvani Bone-Broth' | 2P4R766JCAERYBKHNRSX97SLT |
+```
+
+Save the concatenated dump to e.g. `/tmp/lgo-full.txt`.
+
+> **Naming convention** (from the Dozenmater clan we tested against):
+> `<E>` = Emmy's tribesmen, `<Q>` = her husband's, hyphenated tribe-style
+> names = third clanmate's. The CLI's `--owner-suffix E` filter relies on
+> this convention; for clans with different naming, leave it off and pass
+> additional `--players` names if needed.
+
+### 2. (Optional) Capture the training log
+
+In game, open **Training ground → Training Log**, scroll to cover the period
+since your last roster export, and copy the text into a file (e.g.
+`/tmp/training.txt`). The CLI looks for two phrasings:
+
+```
+... successfully raised the proficiency cap of [<weapon-or-skill>] to Lv.<n> ...
+... successfully upgraded the talent [<talent>] Lv.<x> to [<talent>] Lv.<y> ...
+```
+
+Other rows ("added a training task", "has been completed", "modified") are
+ignored.
+
+### 3. Run the importer
+
+```sh
+node cli.js \
+  --lgo /tmp/lgo-full.txt \
+  --existing /path/to/your/clan_backup.json \
+  --out /path/to/clan_backup_merged.json \
+  --owner-suffix E \
+  --training-log /tmp/training.txt
+```
+
+The CLI prints a change report to stderr:
+
+```
+=== Merge report ===
+  unchanged:    25
+  added:        2
+     + 2X2B72IRRDP2PLZI6JZ4EU5MV  Gerard
+     + 3XK80TAXKJ7JN5XE92HQA5OF5  Boris
+  renamed:      0
+  marked body:  0
+  → final roster size: 27
+
+=== Training-log deltas ===
+  events parsed:   13
+  weapon bumps:    1
+     ⚔ Andaria  Blade: cap 105 → 117
+  skill bumps:     0
+  talent bumps:    0
+```
+
+`--dry-run` skips writing the output and just prints the report.
+
+### 4. Load it in ClanManager
+
+Open ClanManager in the browser and use the existing **Restore JSON** button
+(top-right toolbar). Pick the file the CLI wrote.
+
+## All flags
+
+```
+--lgo            Path to the lgo text dump (required).
+--existing       Path to your current clan_backup.json (required).
+--out            Where to write the merged clan_backup.json
+                 (required unless --dry-run).
+--owner-suffix   Filter lgo to entries whose name ends in " <X>", e.g. E or Q.
+                 Default: no filter (every clan-owned thing).
+--rename-policy  keep-roster (default) | adopt-lgo
+                 keep-roster: don't overwrite roster names with in-game names
+                 adopt-lgo:   overwrite. Use when you've renamed a tribesman
+                              in-game and want the change reflected.
+--no-mark-body   Don't auto-flag tribesmen missing from lgo as is_body=true.
+                 Default behavior assumes "missing from lgo" = died and burnt.
+--dry-run        Print the report; don't write the output file.
+--players        Comma-separated extra player names to filter out (defaults
+                 already exclude vehicles, "Cat", "Donkey", "Boar", and the
+                 three players in the Dozenmater test clan).
+--training-log   Path to a copy-paste of the in-game Training ground log.
+                 Applies weapon-cap and talent-level deltas to the merged
+                 roster.
+```
+
+## What the CLI doesn't do
+
+- Auto-fetch the lgo dump or training log. The MCP commands are simple enough
+  that you (or Claude) can run them directly; baking that into the CLI would
+  add MCP coupling without much benefit.
+- Update `level`, attribute points (Per/Agi/Phy/End/Str), or skill *current*
+  values. Those live only in the BLOB.
+- Touch the existing roster's `notes`, `groups`, `tags`, `title`, `location`,
+  or `tribe`. Those are user-curated.
+- Backfill the `<unknown>` profession or `tribe` for new captures. The
+  skeletons land empty; you fill them in via the UI.
+
+## Refreshing skills, weapons, and stats from screenshots
+
+`cli.js` plus the training log handle the *roster shape* — who's in the clan,
+what their cap is on every weapon you've trained, who's new, who died. But
+**level, the 5 attributes (Per/Agi/Phy/End/Str), and every skill `current`
+value live only in the BLOB**, which we can't parse. Updating those requires
+two screenshots per tribesman: their **Character → Ability** tab and
+**Character → Proficiency** tab.
+
+Workflow:
+
+1. In-game, tab through your tribesmen. For each, capture both tabs.
+2. Open a fresh Claude session, paste the contents of
+   [`EXTRACT_PROMPT.md`](EXTRACT_PROMPT.md), and attach the screenshots.
+3. Claude returns a single `clan-screenshot-patch-v1` JSON document. Save it
+   to e.g. `/tmp/patch.json`.
+4. Apply it:
+
+   ```sh
+   node apply-patch.js \
+     --patch /tmp/patch.json \
+     --existing /path/to/clan_backup.json \
+     --out /path/to/clan_backup_patched.json
+   ```
+
+5. Load the patched JSON via **Restore JSON** in ClanManager.
+
+The patch tool only touches fields the patch contains. Talents, notes,
+groups, tags, location, `is_body` — anything user-curated — is preserved.
+
+> **Validated end-to-end on Andaria.** A single patch produced 28 changes:
+> 22 previously-blank skill / weapon `current` values populated, 4 cap
+> corrections (the manual entries had drifted), and 2 attribute corrections.
+
+## Files
+
+```
+tools/import-world-db/
+  cli.js                 - argument parsing + orchestration for the lgo / training-log flow
+  parse-lgo.js           - regex parser for lgo output rows
+  merge.js               - merge logic (unchanged / added / renamed / marked-body)
+  parse-training-log.js  - regex parser for in-game Training ground log events
+  apply-training.js      - apply parsed training deltas to a roster
+  apply-patch.js         - apply a screenshot-extracted patch to a roster
+  EXTRACT_PROMPT.md      - vision prompt to paste into a Claude session for screenshot extraction
+  schema.md              - what we learned about world.db, Soulmask BLOBs, and RCON
+  README.md              - this file
+```

--- a/tools/import-world-db/apply-patch.js
+++ b/tools/import-world-db/apply-patch.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// Apply a screenshot-extracted "tribesman patch" JSON to a ClanManager roster.
+//
+// The patch is produced by Claude (or any vision-capable model) reading the
+// in-game Character → Ability and Character → Proficiency tabs. See
+// EXTRACT_PROMPT.md for the documented extraction prompt and skill name map.
+//
+// Patch shape:
+//   {
+//     "schema": "clan-screenshot-patch-v1",
+//     "tribesmen": [
+//       {
+//         "match": { "id": "<UID>", "name": "<name>" },   // either is fine; id wins
+//         "level": 50,
+//         "title": "Skilled",
+//         "profession": "Warrior",
+//         "tribe": "Wildwolf",
+//         "attrs": { "Per": 23, "Agi": 29, "Phy": 27, "End": 26, "Str": 23 },
+//         "skills":  { "Lumberjack": { "current": 21, "cap": 84 }, ... },
+//         "weapons": { "Spear":      { "current": 11, "cap": 99 }, ... }
+//       },
+//       ...
+//     ]
+//   }
+//
+// Merge rules:
+//   - Top-level scalar fields (level, title, profession, tribe):
+//     overwrite if present in the patch, otherwise leave alone.
+//   - attrs: replaced wholesale if present.
+//   - skills / weapons: per-key deep merge — only the keys the patch has are
+//     touched. Existing skills/weapons absent from the patch are preserved.
+//     Within a cell, undefined fields don't overwrite (so a patch with only
+//     {cap: 84} preserves the existing current value).
+//   - is_body, location, notes, groups, tags, talents: NEVER touched. Those
+//     are user-curated and the screenshots can't represent them.
+//
+// Usage:
+//   node apply-patch.js \
+//     --patch <path-to-patch.json> \
+//     --existing <clan_backup.json> \
+//     --out <merged.json> \
+//     [--dry-run]
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const SCHEMA_VERSION = "clan-screenshot-patch-v1";
+
+function parseArgs(argv) {
+  const args = { patch: null, existing: null, out: null, dryRun: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    switch (a) {
+      case "--patch":     args.patch = next(); break;
+      case "--existing":  args.existing = next(); break;
+      case "--out":       args.out = next(); break;
+      case "--dry-run":   args.dryRun = true; break;
+      case "-h": case "--help": printHelpAndExit(0);
+      default:
+        console.error(`unknown arg: ${a}`);
+        printHelpAndExit(2);
+    }
+  }
+  if (!args.patch || !args.existing || (!args.out && !args.dryRun)) {
+    console.error("--patch, --existing, and --out (or --dry-run) are required");
+    printHelpAndExit(2);
+  }
+  return args;
+}
+
+function printHelpAndExit(code) {
+  console.log(`Usage: node apply-patch.js --patch <file> --existing <file> --out <file> [--dry-run]
+
+Apply a screenshot-extracted patch JSON to a ClanManager roster.
+
+Options:
+  --patch     Path to the patch JSON (clan-screenshot-patch-v1).
+  --existing  Path to the current clan_backup.json.
+  --out       Path to write the patched clan_backup.json.
+  --dry-run   Print the change report; don't write the output file.
+
+See EXTRACT_PROMPT.md for how to produce the patch JSON from screenshots.`);
+  process.exit(code);
+}
+
+function loadJson(p) {
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+/**
+ * Find the roster entry that a patch entry refers to. Prefers `match.id`,
+ * falls back to case-insensitive `match.name`.
+ */
+function findTarget(roster, match) {
+  if (!match) return null;
+  if (match.id) {
+    const byId = roster.find((t) => t.id === match.id);
+    if (byId) return byId;
+  }
+  if (match.name) {
+    const lower = match.name.toLowerCase();
+    return roster.find((t) => t.name && t.name.toLowerCase() === lower) || null;
+  }
+  return null;
+}
+
+/**
+ * Merge a single patch entry into the matching roster entry, in place.
+ * Returns a list of changed-field descriptors for reporting.
+ */
+function applyOne(target, patch) {
+  const changes = [];
+  const setIfDifferent = (key) => {
+    if (!(key in patch)) return;
+    if (target[key] !== patch[key]) {
+      changes.push({ field: key, from: target[key], to: patch[key] });
+      target[key] = patch[key];
+    }
+  };
+  setIfDifferent("level");
+  setIfDifferent("title");
+  setIfDifferent("profession");
+  setIfDifferent("tribe");
+
+  if (patch.attrs && typeof patch.attrs === "object") {
+    target.attrs = target.attrs || {};
+    for (const k of ["Per", "Agi", "Phy", "End", "Str"]) {
+      if (k in patch.attrs && target.attrs[k] !== patch.attrs[k]) {
+        changes.push({ field: `attrs.${k}`, from: target.attrs[k], to: patch.attrs[k] });
+        target.attrs[k] = patch.attrs[k];
+      }
+    }
+  }
+
+  if (patch.skills && typeof patch.skills === "object") {
+    target.skills = target.skills || {};
+    for (const [name, cell] of Object.entries(patch.skills)) {
+      const cur = target.skills[name] || { current: null, cap: null };
+      const merged = { current: cur.current, cap: cur.cap };
+      if (cell.current !== undefined && merged.current !== cell.current) {
+        changes.push({ field: `skills.${name}.current`, from: merged.current, to: cell.current });
+        merged.current = cell.current;
+      }
+      if (cell.cap !== undefined && merged.cap !== cell.cap) {
+        changes.push({ field: `skills.${name}.cap`, from: merged.cap, to: cell.cap });
+        merged.cap = cell.cap;
+      }
+      target.skills[name] = merged;
+    }
+  }
+
+  if (patch.weapons && typeof patch.weapons === "object") {
+    target.weapons = target.weapons || {};
+    for (const [name, cell] of Object.entries(patch.weapons)) {
+      const cur = target.weapons[name] || { current: null, cap: null };
+      const merged = { current: cur.current, cap: cur.cap };
+      if (cell.current !== undefined && merged.current !== cell.current) {
+        changes.push({ field: `weapons.${name}.current`, from: merged.current, to: cell.current });
+        merged.current = cell.current;
+      }
+      if (cell.cap !== undefined && merged.cap !== cell.cap) {
+        changes.push({ field: `weapons.${name}.cap`, from: merged.cap, to: cell.cap });
+        merged.cap = cell.cap;
+      }
+      target.weapons[name] = merged;
+    }
+  }
+
+  return changes;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const patch = loadJson(args.patch);
+  const existing = loadJson(args.existing);
+
+  if (patch.schema && patch.schema !== SCHEMA_VERSION) {
+    console.error(`warning: patch schema "${patch.schema}" — expected "${SCHEMA_VERSION}"`);
+  }
+  if (!Array.isArray(patch.tribesmen)) {
+    console.error("patch is missing a `tribesmen` array");
+    process.exit(2);
+  }
+  if (!Array.isArray(existing.roster)) {
+    console.error("existing is missing a `roster` array");
+    process.exit(2);
+  }
+
+  console.error(`=== Apply patch ===`);
+  console.error(`  patch:      ${path.basename(args.patch)}  (${patch.tribesmen.length} entries)`);
+  console.error(`  existing:   ${path.basename(args.existing)}  (${existing.roster.length} tribesmen)`);
+  console.error("");
+
+  const unmatched = [];
+  let totalChanges = 0;
+  for (const entry of patch.tribesmen) {
+    const target = findTarget(existing.roster, entry.match);
+    if (!target) {
+      unmatched.push(entry.match);
+      console.error(`  ? unmatched: ${JSON.stringify(entry.match)}`);
+      continue;
+    }
+    const changes = applyOne(target, entry);
+    totalChanges += changes.length;
+    if (changes.length === 0) {
+      console.error(`  · ${target.name} (${target.id})  no changes`);
+      continue;
+    }
+    console.error(`  ✎ ${target.name} (${target.id})  ${changes.length} change(s):`);
+    for (const c of changes) {
+      const fmt = (v) => (v === null || v === undefined ? "—" : JSON.stringify(v));
+      console.error(`       ${c.field}: ${fmt(c.from)} → ${fmt(c.to)}`);
+    }
+  }
+
+  console.error("");
+  console.error(`  total changes: ${totalChanges}`);
+  if (unmatched.length) console.error(`  unmatched:     ${unmatched.length}`);
+
+  if (args.dryRun) {
+    console.error(`\n[dry-run] not writing output`);
+    return;
+  }
+
+  const out = {
+    ...existing,
+    roster: existing.roster, // already mutated in place
+    exported: new Date().toISOString(),
+  };
+  fs.writeFileSync(args.out, JSON.stringify(out, null, 2));
+  console.error(`\n[ok] wrote ${args.out}`);
+}
+
+main();

--- a/tools/import-world-db/apply-training.js
+++ b/tools/import-world-db/apply-training.js
@@ -1,0 +1,136 @@
+// Apply parsed training-log deltas to a roster (mutates each tribesman's
+// weapons / skills / talents).
+//
+// The training log uses square-bracketed names like [Blade], [Lumberjack],
+// [Throw Dodge]. ClanManager's data model splits these across three buckets:
+//   - weapons (9): Spear, Shield, Dual-blade, Great Sword, Spiked Whip, Blade,
+//     Bow, Gauntlets, Hammer
+//   - skills  (14): Lumberjack, Miner, Gatherer, Farmer, Weaver, Potter,
+//     Carpenter, Tanner, Kiln Worker, Craftsman, Alchemist, Cook,
+//     Blacksmith, Armorer
+//   - talents (~250, see data/talents.json)
+//
+// The classifier first checks weapons (smallest set, exact match), then
+// skills, then falls through to "unknown". Unknown caps are reported but not
+// applied — the user reviews them by hand.
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const WEAPONS = new Set([
+  "Spear", "Shield", "Dual-blade", "Great Sword", "Spiked Whip",
+  "Blade", "Bow", "Gauntlets", "Hammer",
+]);
+const SKILLS = new Set([
+  "Lumberjack", "Miner", "Gatherer", "Farmer", "Weaver", "Potter",
+  "Carpenter", "Tanner", "Kiln Worker", "Craftsman", "Alchemist",
+  "Cook", "Blacksmith", "Armorer",
+]);
+
+function loadTalentCatalog(repoRoot) {
+  // talents.json sits at <repoRoot>/data/talents.json relative to this tool.
+  const p = path.join(repoRoot, "data", "talents.json");
+  if (!fs.existsSync(p)) return null;
+  try {
+    const data = JSON.parse(fs.readFileSync(p, "utf8"));
+    const arr = Array.isArray(data) ? data : data.talents || [];
+    const byName = new Map();
+    for (const t of arr) {
+      if (t && t.name) byName.set(t.name, t);
+    }
+    return byName;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @typedef {Object} TrainingApplyReport
+ * @property {object[]} weaponBumps   - { tribesman, weapon, oldCap, newCap }
+ * @property {object[]} skillBumps    - { tribesman, skill, oldCap, newCap }
+ * @property {object[]} talentBumps   - { tribesman, talent, oldLevel, newLevel }
+ * @property {object[]} talentAdds    - { tribesman, talent, level } when not already on tribesman
+ * @property {object[]} unmatchedNames - { tribesman } when no roster entry found
+ * @property {object[]} unknownTargets - { tribesman, target, level } cap event whose target isn't a known weapon/skill
+ * @property {object[]} unknownTalents - { tribesman, talent } when talent name isn't in the catalog
+ */
+
+/**
+ * Apply reduced training-log events to a roster (mutates).
+ *
+ * @param {object[]} roster - Tribesman array
+ * @param {Map} reducedEvents - output of parseTrainingLog/reduceEvents
+ * @param {Map<string, object>|null} talentCatalog - name → talent meta (for icon lookup)
+ * @returns {TrainingApplyReport}
+ */
+function applyTrainingDeltas(roster, reducedEvents, talentCatalog) {
+  const report = {
+    weaponBumps: [], skillBumps: [], talentBumps: [], talentAdds: [],
+    unmatchedNames: [], unknownTargets: [], unknownTalents: [],
+  };
+
+  // Index roster by name (case-insensitive). If duplicates, the first wins.
+  const byName = new Map();
+  for (const t of roster) {
+    const k = t.name.toLowerCase();
+    if (!byName.has(k)) byName.set(k, t);
+  }
+
+  for (const [tribesmanName, deltas] of reducedEvents) {
+    const t = byName.get(tribesmanName.toLowerCase());
+    if (!t) {
+      report.unmatchedNames.push({ tribesman: tribesmanName });
+      continue;
+    }
+
+    // Apply weapon/skill caps
+    for (const [target, newLevel] of deltas.caps) {
+      if (WEAPONS.has(target)) {
+        t.weapons = t.weapons || {};
+        const cell = t.weapons[target] || { current: null, cap: null };
+        const oldCap = cell.cap;
+        if (oldCap == null || newLevel > oldCap) {
+          t.weapons[target] = { current: cell.current, cap: newLevel };
+          report.weaponBumps.push({ tribesman: tribesmanName, weapon: target, oldCap, newCap: newLevel });
+        }
+      } else if (SKILLS.has(target)) {
+        t.skills = t.skills || {};
+        const cell = t.skills[target] || { current: null, cap: null };
+        const oldCap = cell.cap;
+        if (oldCap == null || newLevel > oldCap) {
+          t.skills[target] = { current: cell.current, cap: newLevel };
+          report.skillBumps.push({ tribesman: tribesmanName, skill: target, oldCap, newCap: newLevel });
+        }
+      } else {
+        report.unknownTargets.push({ tribesman: tribesmanName, target, level: newLevel });
+      }
+    }
+
+    // Apply talent levels
+    for (const [talentName, newLevel] of deltas.talents) {
+      t.talents = t.talents || [];
+      const existing = t.talents.find((x) => x.name === talentName);
+      if (existing) {
+        if (newLevel > (existing.level || 0)) {
+          report.talentBumps.push({ tribesman: tribesmanName, talent: talentName, oldLevel: existing.level, newLevel });
+          existing.level = newLevel;
+        }
+      } else {
+        // Need an icon — look it up in the catalog if available
+        const meta = talentCatalog ? talentCatalog.get(talentName) : null;
+        if (!meta) {
+          report.unknownTalents.push({ tribesman: tribesmanName, talent: talentName });
+          continue;
+        }
+        t.talents.push({ name: talentName, level: newLevel, icon: meta.icon || "" });
+        report.talentAdds.push({ tribesman: tribesmanName, talent: talentName, level: newLevel });
+      }
+    }
+  }
+
+  return report;
+}
+
+module.exports = { applyTrainingDeltas, loadTalentCatalog, WEAPONS, SKILLS };

--- a/tools/import-world-db/cli.js
+++ b/tools/import-world-db/cli.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// CLI: take an `lgo` text dump + an existing clan_backup.json and produce a
+// merged clan_backup.json that adds new captures, flags renames, and marks
+// missing-from-game entries as bodies.
+//
+// Usage:
+//   node cli.js \
+//     --lgo <path-to-lgo-dump.txt> \
+//     --existing <path-to-current-clan_backup.json> \
+//     --out <path-to-write-new-clan_backup.json> \
+//     [--owner-suffix E]   # filter lgo to entries with " <E>" (default: include all-suffix entries; pass "" to disable filter)
+//     [--rename-policy keep-roster|adopt-lgo]   # default keep-roster
+//     [--no-mark-body]     # don't auto-flag missing tribesmen as bodies
+//     [--dry-run]          # print the report; don't write
+//     [--players <name1,name2,...>]  # extra player names to filter out (in addition to common ones)
+//
+// The output JSON matches the shape consumed by ClanManager's "Restore JSON"
+// button (see app.js:1313/1323 — { roster, groups, tags, plans, version,
+// exported }).
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { parseLgo, filterTribesmen } = require("./parse-lgo");
+const { mergeRoster } = require("./merge");
+const { parseTrainingLog, reduceEvents } = require("./parse-training-log");
+const { applyTrainingDeltas, loadTalentCatalog } = require("./apply-training");
+
+const STORAGE_VERSION = 2; // matches app.js STORAGE_VERSION
+
+function parseArgs(argv) {
+  const args = {
+    lgo: null,
+    existing: null,
+    out: null,
+    ownerSuffix: undefined, // undefined = no suffix filter
+    renamePolicy: "keep-roster",
+    markBody: true,
+    dryRun: false,
+    players: [],
+    trainingLog: null,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    switch (a) {
+      case "--lgo":           args.lgo = next(); break;
+      case "--existing":      args.existing = next(); break;
+      case "--out":           args.out = next(); break;
+      case "--owner-suffix":  args.ownerSuffix = next(); break;
+      case "--rename-policy": args.renamePolicy = next(); break;
+      case "--no-mark-body":  args.markBody = false; break;
+      case "--dry-run":       args.dryRun = true; break;
+      case "--players":       args.players = next().split(",").map((s) => s.trim()).filter(Boolean); break;
+      case "--training-log":  args.trainingLog = next(); break;
+      case "-h": case "--help":
+        printHelpAndExit(0); break;
+      default:
+        console.error(`unknown arg: ${a}`);
+        printHelpAndExit(2);
+    }
+  }
+  if (!args.lgo || !args.existing || (!args.out && !args.dryRun)) {
+    console.error("--lgo, --existing, and --out (or --dry-run) are required");
+    printHelpAndExit(2);
+  }
+  return args;
+}
+
+function printHelpAndExit(code) {
+  const usage = `Usage: node cli.js --lgo <path> --existing <path> --out <path> [options]
+
+Options:
+  --lgo            Path to a text dump of \`lgo <guild_uid>\` (pages 1+2 concatenated)
+  --existing       Path to your current clan_backup.json
+  --out            Where to write the merged clan_backup.json
+  --owner-suffix   Filter lgo to entries whose name ends in " <X>". Default: no filter.
+                   On the test clan, "<E>" = Emmy's, "<Q>" = husband's.
+  --rename-policy  keep-roster (default) | adopt-lgo
+                   keep-roster: ignore in-game renames, keep your existing roster names
+                   adopt-lgo:   overwrite roster name with the in-game name
+  --no-mark-body   Don't flag tribesmen missing from lgo as is_body=true
+  --dry-run        Print the change report; don't write the output file
+  --players        Comma-separated extra player names to filter out
+                   (defaults already exclude common-named entities like 'Cat', 'Donkey', 'Boar', and boats/airships)
+  --training-log   Path to a copy-paste of the in-game "Training ground" log.
+                   When provided, weapon/skill caps and talent levels are
+                   advanced based on the log events. Lines that don't match
+                   are silently skipped; events for tribesmen not in the
+                   merged roster are reported but not applied.
+
+The output is consumed by ClanManager's "Restore JSON" button.`;
+  console.log(usage);
+  process.exit(code);
+}
+
+function loadJson(p) {
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  const lgoText = fs.readFileSync(args.lgo, "utf8");
+  const existing = loadJson(args.existing);
+
+  let entries = parseLgo(lgoText);
+  console.error(`[lgo] parsed ${entries.length} entries from ${path.basename(args.lgo)}`);
+
+  if (args.ownerSuffix !== undefined && args.ownerSuffix !== "") {
+    const before = entries.length;
+    entries = entries.filter((e) => e.suffix === args.ownerSuffix);
+    console.error(`[lgo] filtered by suffix "${args.ownerSuffix}": ${before} → ${entries.length}`);
+  }
+
+  // Always strip non-tribesman entities (vehicles, animals, players, etc.)
+  const builtInPlayers = ["Emmy", "Heimart", "Aruvak Bone-Chanter", "Aruvak Bone‑Chanter"];
+  const tribesmen = filterTribesmen(entries, [...builtInPlayers, ...args.players]);
+  if (tribesmen.length !== entries.length) {
+    console.error(`[lgo] filtered out ${entries.length - tribesmen.length} non-tribesman entities (vehicles/animals/players/buildings)`);
+  }
+  console.error(`[lgo] tribesman entries to merge: ${tribesmen.length}`);
+
+  const { roster: mergedRoster, report } = mergeRoster(existing.roster || [], tribesmen, {
+    renamePolicy: args.renamePolicy,
+    markMissingAsBody: args.markBody,
+  });
+
+  // Print report
+  console.error(`\n=== Merge report ===`);
+  console.error(`  unchanged:    ${report.unchanged}`);
+  console.error(`  added:        ${report.added.length}`);
+  for (const t of report.added) console.error(`     + ${t.id}  ${t.name}`);
+  console.error(`  renamed:      ${report.renamed.length}`);
+  for (const r of report.renamed) console.error(`     ~ ${r.uid}  roster:'${r.rosterName}'  lgo:'${r.lgoName}'`);
+  console.error(`  marked body:  ${report.marked_body.length}`);
+  for (const m of report.marked_body) console.error(`     † ${m.uid}  ${m.name}`);
+  console.error(`  → final roster size: ${mergedRoster.length}`);
+
+  // Optionally apply training-log deltas
+  if (args.trainingLog) {
+    const text = fs.readFileSync(args.trainingLog, "utf8");
+    const events = parseTrainingLog(text);
+    const reduced = reduceEvents(events);
+    const repoRoot = path.resolve(__dirname, "..", "..");
+    const catalog = loadTalentCatalog(repoRoot);
+    const t = applyTrainingDeltas(mergedRoster, reduced, catalog);
+
+    console.error(`\n=== Training-log deltas ===`);
+    console.error(`  events parsed:   ${events.length}`);
+    console.error(`  weapon bumps:    ${t.weaponBumps.length}`);
+    for (const b of t.weaponBumps) console.error(`     ⚔ ${b.tribesman}  ${b.weapon}: cap ${b.oldCap ?? "-"} → ${b.newCap}`);
+    console.error(`  skill bumps:     ${t.skillBumps.length}`);
+    for (const b of t.skillBumps) console.error(`     ⚒ ${b.tribesman}  ${b.skill}: cap ${b.oldCap ?? "-"} → ${b.newCap}`);
+    console.error(`  talent bumps:    ${t.talentBumps.length}`);
+    for (const b of t.talentBumps) console.error(`     ★ ${b.tribesman}  ${b.talent}: Lv.${b.oldLevel ?? "-"} → Lv.${b.newLevel}`);
+    if (t.talentAdds.length) {
+      console.error(`  talents added:   ${t.talentAdds.length}`);
+      for (const a of t.talentAdds) console.error(`     + ${a.tribesman}  ${a.talent} (Lv.${a.level})`);
+    }
+    if (t.unmatchedNames.length) {
+      console.error(`  unmatched names: ${t.unmatchedNames.length}`);
+      for (const u of t.unmatchedNames) console.error(`     ? ${u.tribesman}  (no roster entry)`);
+    }
+    if (t.unknownTargets.length) {
+      console.error(`  unknown weapon/skill targets: ${t.unknownTargets.length}`);
+      for (const u of t.unknownTargets) console.error(`     ? ${u.tribesman}  [${u.target}] Lv.${u.level}  (not a known weapon or skill)`);
+    }
+    if (t.unknownTalents.length) {
+      console.error(`  unknown talents: ${t.unknownTalents.length}`);
+      for (const u of t.unknownTalents) console.error(`     ? ${u.tribesman}  [${u.talent}]  (not in data/talents.json)`);
+    }
+  }
+
+  if (args.dryRun) {
+    console.error(`\n[dry-run] not writing output`);
+    return;
+  }
+
+  const out = {
+    roster: mergedRoster,
+    groups: existing.groups || [],
+    tags: existing.tags || [],
+    plans: existing.plans || [],
+    version: existing.version || STORAGE_VERSION,
+    exported: new Date().toISOString(),
+  };
+  if (existing.calibration !== undefined) out.calibration = existing.calibration;
+
+  fs.writeFileSync(args.out, JSON.stringify(out, null, 2));
+  console.error(`\n[ok] wrote ${args.out}`);
+}
+
+main();

--- a/tools/import-world-db/merge.js
+++ b/tools/import-world-db/merge.js
@@ -1,0 +1,117 @@
+// Merge `lgo`-derived tribesman list into an existing ClanManager roster.
+//
+// Rules (preserve user-curated data, add new captures, flag oddities):
+//   1. UID exists in roster, name matches            → keep roster entry as-is
+//   2. UID exists in roster, name differs            → keep roster entry, append
+//                                                       a note like "in-game name: Foo"
+//                                                       (configurable)
+//   3. UID exists in roster but is missing from lgo  → mark `is_body: true` if
+//                                                       not already (the tribesman
+//                                                       died and was burnt or transferred
+//                                                       out of the clan). Do NOT delete.
+//   4. UID present in lgo, missing from roster       → add a fresh skeleton.
+//
+// The caller supplies `defaultProfession` for new skeletons. Skill / weapon /
+// talent fields are left empty — the user fills them in via the ClanManager UI.
+
+"use strict";
+
+/**
+ * Build a fresh Tribesman skeleton.
+ *
+ * @param {string} uid - the lgo UID, used as `id`
+ * @param {string} name - the lgo name (without <E>/<Q> suffix)
+ * @returns {object} a Tribesman object matching types.js shape
+ */
+function newSkeleton(uid, name) {
+  return {
+    id: uid,
+    name,
+    level: null,
+    title: "",
+    profession: "",
+    tribe: "",
+    trait: "",
+    location: "",
+    is_body: false,
+    skills: {},
+    weapons: {},
+    attrs: { Per: null, Agi: null, Phy: null, End: null, Str: null },
+    talents: [],
+    groups: [],
+    tags: [],
+    notes: "",
+  };
+}
+
+/**
+ * @typedef {Object} MergeReport
+ * @property {object[]} added    - new skeletons appended to the roster
+ * @property {object[]} renamed  - { uid, rosterName, lgoName } for name mismatches
+ * @property {object[]} marked_body - tribesmen present in roster but absent from lgo, set is_body=true
+ * @property {number} unchanged  - count of UIDs preserved as-is
+ */
+
+/**
+ * @param {object[]} roster - the existing tribesman array
+ * @param {import("./parse-lgo").LgoEntry[]} lgoEntries - already-filtered tribesman entries
+ * @param {object} options
+ * @param {"keep-roster"|"adopt-lgo"} [options.renamePolicy="keep-roster"]
+ * @param {boolean} [options.markMissingAsBody=true]
+ * @returns {{ roster: object[], report: MergeReport }}
+ */
+function mergeRoster(roster, lgoEntries, options = {}) {
+  const renamePolicy = options.renamePolicy || "keep-roster";
+  const markMissingAsBody = options.markMissingAsBody !== false;
+
+  const lgoByUid = new Map(lgoEntries.map((e) => [e.uid, e]));
+  const rosterByUid = new Map(roster.map((t) => [t.id, t]));
+
+  const merged = [];
+  const report = { added: [], renamed: [], marked_body: [], unchanged: 0 };
+
+  // Pass 1: keep existing entries (possibly updating notes / is_body flag)
+  for (const t of roster) {
+    const lgoEntry = lgoByUid.get(t.id);
+    if (!lgoEntry) {
+      // Missing from lgo — likely dead or transferred out of clan
+      if (markMissingAsBody && !t.is_body) {
+        const updated = { ...t, is_body: true };
+        merged.push(updated);
+        report.marked_body.push({ uid: t.id, name: t.name });
+      } else {
+        merged.push(t);
+        report.unchanged++;
+      }
+      continue;
+    }
+    if (t.name !== lgoEntry.name) {
+      report.renamed.push({
+        uid: t.id,
+        rosterName: t.name,
+        lgoName: lgoEntry.name,
+      });
+      if (renamePolicy === "adopt-lgo") {
+        merged.push({ ...t, name: lgoEntry.name });
+      } else {
+        // keep-roster: don't change the roster name; just record the mismatch
+        merged.push(t);
+      }
+    } else {
+      merged.push(t);
+      report.unchanged++;
+    }
+  }
+
+  // Pass 2: append new captures
+  for (const e of lgoEntries) {
+    if (rosterByUid.has(e.uid)) continue;
+    const skel = newSkeleton(e.uid, e.name);
+    merged.push(skel);
+    report.added.push(skel);
+  }
+
+  return { roster: merged, report };
+}
+
+module.exports = { newSkeleton, mergeRoster };

--- a/tools/import-world-db/parse-lgo.js
+++ b/tools/import-world-db/parse-lgo.js
@@ -1,0 +1,86 @@
+// Parse the text output of Soulmask's `lgo <guild_uid>` RCON command into a
+// list of { name, uid, suffix } records.
+//
+// Each row in the output looks like:
+//   |             'Andaria <E>' | AD41LS8M7FDBQV6IHZX9G9NGU |
+// or:
+//   |          'Hunter N 1 <Q>' | 9GM5T6GTESKAMTNH72KLACG6W |
+// or:
+//   |    'Belvani Bone‑Broth' | 2P4R766JCAERYBKHNRSX97SLT |
+//
+// The header row and the interactive-mode footer block are ignored.
+// Pages 1 and 2 of a paginated lgo response can be concatenated as input.
+//
+// `<E>` and `<Q>` suffixes encode owner-shorthand on this server:
+//   <E> → Emmy's tribesmen
+//   <Q> → husband's tribesmen
+//   (no suffix, hyphenated tribe-style name) → third clanmate's tribesmen
+//   (no suffix, also includes player names + vehicles + animals)
+// The CLI consumer is responsible for filtering by suffix.
+
+"use strict";
+
+const ROW_RE = /^\|\s*'([^']+)'\s*\|\s*([A-Z0-9]{20,})\s*\|\s*$/;
+const SUFFIX_RE = /\s*<([A-Z])>\s*$/;
+
+/**
+ * @typedef {Object} LgoEntry
+ * @property {string} rawName  - exact name as printed (e.g. "Andaria <E>", "Hunter N 1 <Q>")
+ * @property {string} name     - rawName with the trailing suffix (and surrounding whitespace) stripped
+ * @property {string|null} suffix  - "E", "Q", or null if absent
+ * @property {string} uid      - the 25-ish-char alphanumeric UID
+ */
+
+/**
+ * Parse a multi-line lgo response into entries.
+ * @param {string} text - the raw RCON output
+ * @returns {LgoEntry[]}
+ */
+function parseLgo(text) {
+  const entries = [];
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    const m = ROW_RE.exec(line);
+    if (!m) continue;
+    const rawName = m[1].trim();
+    const uid = m[2];
+    if (rawName === "Name") continue; // header row
+    const suffixMatch = SUFFIX_RE.exec(rawName);
+    const suffix = suffixMatch ? suffixMatch[1] : null;
+    const name = suffix ? rawName.replace(SUFFIX_RE, "").trim() : rawName;
+    entries.push({ rawName, name, suffix, uid });
+  }
+  return entries;
+}
+
+/**
+ * Filter entries that look like *tribesmen*, excluding vehicles, buildings,
+ * pets, and player characters.
+ *
+ * Heuristics — based on what `lgo` returns for the test clan ("Dozenmater"):
+ *  - Vehicles end with "Boat" or "Airship"
+ *  - "Cat", "Donkey", "Boar" — animals owned by the clan (mounts/livestock)
+ *  - Names that contain "-Farm" — buildings (e.g. "Creas Marrow-Farm")
+ *  - Player human names match the playerNames set (passed in)
+ *  - Items like "Emmy's MaoXian" — possessive pet/object
+ *  - Everything else: tribesman
+ *
+ * @param {LgoEntry[]} entries
+ * @param {string[]} playerNames  - names from `lap` (List_AllPlayers) to exclude
+ * @returns {LgoEntry[]}
+ */
+function filterTribesmen(entries, playerNames = []) {
+  const playerSet = new Set(playerNames.map((n) => n.toLowerCase()));
+  const animalNames = new Set(["cat", "donkey", "boar", "horse", "ostrich"]);
+  return entries.filter((e) => {
+    const lower = e.name.toLowerCase();
+    if (playerSet.has(lower)) return false;
+    if (lower.endsWith(" boat") || lower.endsWith(" airship")) return false;
+    if (lower.includes("-farm")) return false;
+    if (animalNames.has(lower)) return false;
+    if (lower.endsWith("'s maoxian")) return false; // "Emmy's MaoXian" pet
+    return true;
+  });
+}
+
+module.exports = { parseLgo, filterTribesmen };

--- a/tools/import-world-db/parse-training-log.js
+++ b/tools/import-world-db/parse-training-log.js
@@ -1,0 +1,130 @@
+// Parse text copied from Soulmask's in-game "Training ground" log into a list
+// of structured events. The log isn't persisted server-side as plain text;
+// the user has to copy-paste from the client UI.
+//
+// Recognized event shapes (pulled from real screenshots — phrasing matches
+// the English client circa April 2026):
+//
+//   <ts> Tribesman <name>, while performing <player>'s training task [Combat
+//   Skill Improvement (<mentor>, <student>)], successfully raised the
+//   proficiency cap of [<weapon-or-skill>] to Lv.<n> under the instructor's
+//   guidance.
+//
+//   <ts> Tribesman <name>, while performing <player>'s training task [Talent
+//   Upgrade (<mentor>, <student>)], successfully upgraded the talent
+//   [<talent>] Lv.<x> to [<talent>] Lv.<y> under the instructor's guidance.
+//
+// We ignore "added a training task", "modified ...", and "has been completed."
+// rows — those are workflow noise that doesn't change tribesman state.
+
+"use strict";
+
+// We don't try to parse the timestamp into a Date — we only care about
+// applying the latest value per (tribesman, weapon|skill|talent), which the
+// caller resolves by sorting events in file order (the in-game UI lists newest
+// first, so a later occurrence wins iff we sort by file position descending —
+// see applyTrainingDeltas below).
+const CAP_RE = /Tribesman\s+([^,]+?),\s+while performing[^]*?successfully raised the proficiency cap of\s+\[([^\]]+)\]\s+to Lv\.(\d+)/i;
+const TALENT_RE = /Tribesman\s+([^,]+?),\s+while performing[^]*?successfully upgraded the talent\s+\[([^\]]+)\]\s+Lv\.(\d+)\s+to\s+\[([^\]]+)\]\s+Lv\.(\d+)/i;
+
+/**
+ * @typedef {Object} CapEvent
+ * @property {"cap"} kind
+ * @property {string} tribesman   - student name (suffix stripped)
+ * @property {string} target      - the weapon or skill name in [...]
+ * @property {number} level       - new cap value
+ * @property {number} order       - event index in input file (lower = earlier in file)
+ */
+
+/**
+ * @typedef {Object} TalentEvent
+ * @property {"talent"} kind
+ * @property {string} tribesman   - student name (suffix stripped)
+ * @property {string} talent      - talent name in [...]
+ * @property {number} fromLevel
+ * @property {number} toLevel
+ * @property {number} order
+ */
+
+/** @typedef {CapEvent|TalentEvent} TrainingEvent */
+
+const SUFFIX_RE = /\s*<[A-Z]>\s*$/;
+function stripSuffix(name) {
+  return name.replace(SUFFIX_RE, "").trim();
+}
+
+/**
+ * Parse a multi-line dump of training-log events.
+ * @param {string} text
+ * @returns {TrainingEvent[]}
+ */
+function parseTrainingLog(text) {
+  const events = [];
+  // The training log can be split across very long lines or multi-line entries
+  // depending on how the user pasted it. Normalize whitespace into single spaces
+  // first, then split on the boundary between events. Events tend to start with
+  // a date like "Apr 28, 2026," (English client) or a timestamp prefix.
+  const normalized = text.replace(/\s+/g, " ");
+  // Split on "Apr 28, 2026," / "Mar 02, 2026," / etc.
+  const parts = normalized.split(/(?=\b[A-Z][a-z]{2}\s+\d{1,2},\s+\d{4},\s+\d{1,2}:\d{2}:\d{2}\s*(?:AM|PM)\b)/);
+  let order = 0;
+  for (const part of parts) {
+    if (!part.trim()) continue;
+    const cap = CAP_RE.exec(part);
+    if (cap) {
+      events.push({
+        kind: "cap",
+        tribesman: stripSuffix(cap[1]),
+        target: cap[2].trim(),
+        level: parseInt(cap[3], 10),
+        order: order++,
+      });
+      continue;
+    }
+    const tal = TALENT_RE.exec(part);
+    if (tal) {
+      // Sanity: name in [..] should match in both halves
+      if (tal[2].trim() !== tal[4].trim()) continue;
+      events.push({
+        kind: "talent",
+        tribesman: stripSuffix(tal[1]),
+        talent: tal[2].trim(),
+        fromLevel: parseInt(tal[3], 10),
+        toLevel: parseInt(tal[5], 10),
+        order: order++,
+      });
+    }
+  }
+  return events;
+}
+
+/**
+ * Reduce a list of events into per-tribesman target levels.
+ * Strategy: order events by their `order` field. Latest wins per
+ * (tribesman, target). For talents, we keep the highest `toLevel` we've
+ * seen rather than the latest, because partial logs may be missing the
+ * most-recent upgrade.
+ *
+ * @param {TrainingEvent[]} events
+ */
+function reduceEvents(events) {
+  // Map<tribesman, { caps: Map<target, maxLevel>, talents: Map<talent, maxLevel> }>
+  const byTribesman = new Map();
+  const get = (name) => {
+    if (!byTribesman.has(name)) byTribesman.set(name, { caps: new Map(), talents: new Map() });
+    return byTribesman.get(name);
+  };
+  for (const e of events) {
+    const t = get(e.tribesman);
+    if (e.kind === "cap") {
+      const prev = t.caps.get(e.target) ?? 0;
+      if (e.level > prev) t.caps.set(e.target, e.level);
+    } else {
+      const prev = t.talents.get(e.talent) ?? 0;
+      if (e.toLevel > prev) t.talents.set(e.talent, e.toLevel);
+    }
+  }
+  return byTribesman;
+}
+
+module.exports = { parseTrainingLog, reduceEvents, stripSuffix };

--- a/tools/import-world-db/schema.md
+++ b/tools/import-world-db/schema.md
@@ -1,0 +1,393 @@
+# Soulmask `world.db` schema (discovery findings)
+
+This document is the output of Phase 1 of the importer plan. It captures what we
+learned from inspecting a real `world.db` pulled from a Soulmask server running
+the `shifting_sands` Egypt DLC build.
+
+**Source DB:** server `c2574836` ("Punhalla Gaming Vegetables"), Soulmask
+`docker.io/venturenodellc/soulmask:shifting_sands`, fetched 2026-04-28 via
+`get_file_download_url` (the new MCP tool). 42.6 MB / 13,075 rows /
+SQLite 3.31.1 / `PRAGMA integrity_check = ok`.
+
+---
+
+## 1. SQL layout — one table
+
+The entire game world is stored in a **single** table. There are no auxiliary
+tables, views, triggers, or virtual tables.
+
+```sql
+CREATE TABLE actor_table (
+  actor_serial   INTEGER PRIMARY KEY AUTOINCREMENT,
+  server_id      INTEGER NOT NULL,
+  data_version   INTEGER NOT NULL,
+  actor_name     TEXT,                -- unique index
+  actor_level    TEXT,
+  actor_script   TEXT NOT NULL,       -- the Unreal class path
+  actor_owner    TEXT,                -- ALWAYS EMPTY in this dump
+  actor_transf   TEXT,                -- "x,y,z|pitch,yaw,roll" position+rot
+  actor_data     BLOB,                -- the UE-serialized property bag
+  actor_time     TEXT
+);
+CREATE UNIQUE INDEX idx_actor_table_actor_name ON actor_table(actor_name);
+CREATE INDEX idx_actor_table_server_id ON actor_table(server_id);
+CREATE INDEX idx_actor_table_data_version ON actor_table(data_version);
+CREATE INDEX idx_actor_table_actor_level ON actor_table(actor_level);
+CREATE INDEX idx_actor_table_actor_script ON actor_table(actor_script);
+```
+
+**`actor_owner` is empty for all 13,075 rows.** Ownership is encoded inside
+`actor_data`.
+
+`actor_transf` is human-readable: `"x,y,z|pitch,yaw,roll"` decimal floats. Easy
+win for `Tribesman.location` mapping.
+
+---
+
+## 2. `actor_script` taxonomy
+
+`actor_script` is the Unreal class path of the row's actor. Distribution in this
+dump:
+
+| Bucket                                                                 | Count | Notes                                                           |
+| ---------------------------------------------------------------------- | ----- | --------------------------------------------------------------- |
+| `BP_BindBGCompActor`                                                   | 2,463 | Per-player "save state" component — inventory, recipes, mask    |
+| `BP_DongWu_*` (动物 = animals)                                         | ~3,000+ | Wild fauna (boars, scorpions, fish, etc.)                     |
+| `BP_Monster_*` (Egypt DLC)                                             | ~2,500+ | Hostile mobs                                                  |
+| `BP_EgyptDLC_TribeM_*` / `BP_EgyptDLC_TribeF_*` / `BP_EgyptDLC_Exiles_*` / `BP_EgyptDLC_SandBandits_*` | ~2,280 | NPC humans (the "tribesmen" pool — wild + capturable)         |
+| `BP_EgyptDLC_*_Elite_*` / `*_Boss_*`                                   | ~30    | Higher-tier NPC variants                                       |
+| `BP_BGActor_JianZhu_RongQi`                                            | 134   | Container building actors                                       |
+| `BP_TribeBoat_*`                                                       | 54    | Tribe boats                                                     |
+| `/Script/WS.HPlayerState`                                              | 3     | Human players (one row per player who has logged in)            |
+| `BP_GameModeBase_DLC` (`actor_name = 'GAMEMODE'`)                      | 1     | Single global game-mode singleton                               |
+| (`actor_name = 'GAME_SETTINGS'`)                                       | 1     | Server settings singleton                                       |
+| Various `BP_JianZhu_*` (建筑 = building), `BP_GongZuoTai_*` (workstations) | many  | Player-built structures                                       |
+
+The "tribesman" pool we care about is everything under
+`BluePrints/NPC/Human/`. Whether a given row is a *wild* NPC or a *captured /
+recruited* one is **not** distinguishable from `actor_script` alone — the same
+blueprint class is used for both states. The state lives in `actor_data`.
+
+---
+
+## 3. Player rows (`/Script/WS.HPlayerState`)
+
+Three players exist in this DB:
+
+```
+actor_serial  actor_name (Steam ID)  blob_len
+12231         76561197961402170      47,997
+12294         76561198039989161      67,189
+12686         76561197963957472      39,826
+```
+
+`actor_name` for `HPlayerState` is the player's **SteamID64**. This is the
+canonical player handle.
+
+The player's BLOB starts with property `ZhuRenGuid` (主人 GUID = "master GUID")
+of type `StructProperty` — a 16-byte Unreal `FGuid`. This is the player's
+internal GUID and is the value that captured tribesmen reference for ownership
+(see §5).
+
+Other notable properties seen in the player BLOB:
+- `JSBaoGuoComponent` (玩家包裹 = player inventory), `DaoJuList` (道具列表 = item list)
+- `EquipedMJNodeClass` (mask node class), `RMJGZ_M_10` (mask appearance variant)
+- `KeJiShu` (科技树 = research tree), entries like `KJS_GJ_ShiZhi`, `JianZhu_MaoCaoLou`, `WQ_MuTou`, `ZB_*`
+- `LeiJiNoXiu[Lian]` (累积训练 = cumulative training)
+- `LastBeiMaJieTime`, `AlreadyKillWorldBoss`
+- `BodyData`, `AttrZiDongDian` (属性自动点 = auto-allocated attribute points)
+- `MorphName`, face customization
+
+---
+
+## 4. Wild-tribesman BLOB shape
+
+Sample: serial 9259, `BP_EgyptDLC_TribeF_DesertWolf_C`, BLOB 3,953 bytes.
+Visible ASCII property names extracted from the BLOB (decoded from Pinyin where
+applicable):
+
+| Property in BLOB        | Type           | Pinyin / 中文 / meaning                  | Tribesman field this maps to |
+| ----------------------- | -------------- | ----------------------------------------- | ---------------------------- |
+| `GangWeiLeiXing`        | EnumProperty   | 岗位类型 = post type                     | (used for guard/worker role) |
+| `XunLuoBianHao`         | (Int)          | 巡逻编号 = patrol number                 | —                            |
+| `NieLianShuJu`          | StructProperty | 捏脸数据 = face customization            | —                            |
+| `MorphName`             | NameProperty   | face morph variant (e.g. `M_DLC_08`)      | —                            |
+| `BaseDesaturation`, `EyeColor`, `HairColor`, `MultiBoneScale`, `L_breast`, `Height` | Float/Linear | face/body sliders | —                            |
+| `ClanType`              | EnumProperty   | tribe (`CLAN_TYPE_F` etc.)               | `tribe`                      |
+| `ZHIYE`                 | EnumProperty   | 职业 = profession (`ZHIYE_SHOULIE` = hunter, etc.) | **`profession`**     |
+| `MANREN_BODY_*` (e.g. `_STRONG`) | EnumProperty | body type                          | `trait` (?)                  |
+| `huanJingWuQi`          | EnumProperty   | 环境武器 (env weapon: `WUQI_LEIXING_MAO` = spear) | —                  |
+| `HSuperAbilitySet`      | ArrayProperty  | abilities/skills set                     | **`talents`** + **`skills`** |
+| paths under `Game/Blueprints/GAS/Skill/...`, `_JiuZhiPlus.G...` | ObjectProperty | skill/talent class refs (resolves through `data/talents.json`) | `talents` |
+| `_Level`                | Int            | per-skill level                          | (mentor/talent level)        |
+| `_Tag`                  | NameProperty   | per-skill tag                            | —                            |
+| `MinJie`, `ZhiHui`, `TiZhi`, ...others (5 attribs total) | Int | 敏捷/智慧/体质 = Agi/Wis/Phy/... | **`attrs`** (Per/Agi/Phy/End/Str) |
+| `AttributeValueMap`     | MapProperty    | named attribute → value (Health, Food, Water, XinQing) | (resources, not roster) |
+| `Health`, `Food`, `Water`, `XinQing` (心情 = mood) | Float | live stat values     | —                            |
+| `Total` / `LvSet` / `LeiJiNoXiu...` | Int | cumulative XP / training-level pool | `level`              |
+| Large Hex tokens like `AD782C214D842A4FB664D792B3016F02` | (FGuid) | actor / faction / save GUIDs | (used for ownership cross-ref) |
+| `BindBGCompActor`       | ObjectProperty | reference to that NPC's bind component   | —                            |
+| `MorenDaoJuInit`        | (struct array) | 默认道具初始化 = default-items-init      | —                            |
+| `BaoGuoComponent`       | ObjectProperty | (sub-) inventory                         | —                            |
+
+---
+
+## 5. Ownership: tribe vs. owner
+
+`actor_owner` is empty everywhere, so ownership lives inside `actor_data`. We
+verified by extracting all 32-char hex GUIDs from each `HPlayerState` BLOB and
+cross-referencing against every other actor's BLOB.
+
+| GUID (in HPlayerState BLOB)           | Found in N other actors | Skew                                              |
+| ------------------------------------- | ----------------------- | ------------------------------------------------- |
+| `75655F1A47D11D4FB61C48A38C704398`    | 568                     | 562 SavageHorn humans + 6 buildings/extras        |
+| `E6010F234CCD6B4DDB90BBB6CAC6A755`    | 262                     | DesertWolf + Exiles humans                        |
+| `AD782C214D842A4FB664D792B3016F02`    | 11                      | DesertWolf humans                                 |
+| `306692464B02BFD9324AD6922C960D0A`    | 5                       | DesertWolf + Exiles                               |
+| `DBCC38524BA7014DA64D8D9FFBE0F3FF`    | 3                       | game-mode + 2 humans                              |
+| ...                                   | ...                     | ...                                               |
+
+**Interpretation (high confidence):** the high-cardinality GUIDs (568, 262) are
+**tribe / faction IDs** — the SavageHorn tribe, the DesertWolf tribe — which
+each NPC stores a reference to so the game knows what faction they belong to.
+The low-cardinality GUIDs (≤11) are likely **per-player capture markers** — but
+note that the tribe-faction GUIDs and the player-personal GUIDs both flow
+through the same field (`ZhuRenGuid` or similar). The decisive link is the
+exact byte position of the GUID inside the BLOB, which requires walking the UE
+property tree to know which property tag the GUID belongs to.
+
+**For the importer, the right path is:**
+1. Open each candidate tribesman row.
+2. Walk its `actor_data` BLOB as a UE FProperty tag stream.
+3. Read the `ZhuRenGuid` (or equivalent ownership) property.
+4. Compare against the target player's `ZhuRenGuid` (read from the matching
+   `HPlayerState` row's BLOB).
+5. If equal → owned by that player → emit a `Tribesman` JSON.
+
+---
+
+## 6. The hard part — `actor_data` is UE PropertyTag-serialized binary
+
+`actor_data` is **not** JSON, MessagePack, Protobuf, or any other portable
+format. It's the standard Unreal Engine `FPropertyTag` stream produced by
+`UObject::SerializeScriptProperties` (and equivalents for sub-structs and
+component data). To read a value you have to walk a stream of variable-length
+records that look roughly like:
+
+```
+FName   PropertyName       (length-prefixed string)
+FName   PropertyType       (e.g. "IntProperty", "FloatProperty", "StructProperty",
+                            "EnumProperty", "ArrayProperty", "MapProperty",
+                            "NameProperty", "ObjectProperty", "BoolProperty",
+                            "ByteProperty")
+int32   Size               (bytes of value to follow)
+int32   ArrayIndex
+[type-specific tag tail]   (e.g. for StructProperty: another FName for inner struct type;
+                            for EnumProperty: an FName for the enum type;
+                            for ArrayProperty/MapProperty: inner-type FName(s);
+                            for BoolProperty: a single byte;
+                            for ByteProperty: an FName for the enum)
+[Size bytes of value]
+```
+
+The stream terminates when it reads `FName == "None"`.
+
+**Property names are Pinyin-romanized Chinese** (the game was developed in
+Chinese-first, then Pinyin-tagged for the engine's name table). Many of the
+fields we care about (`ZhiYe`, `MinJie`, `HSuperAbilitySet`, `ZhuRenGuid`,
+`ClanType`, `XinQing`) are documented above.
+
+### What we need
+
+A minimal UE PropertyTag walker that:
+1. Reads `FName` (4-byte signed int length, then ASCII bytes, then `\0`).
+   Length zero or negative → end of stream / `None`.
+2. Switches on the type FName, parses any type-specific tail, then returns the
+   raw value bytes (so we can recurse into structs and arrays).
+3. Stops at `None` and returns a `dict` of `{ propname: value }`.
+
+Estimate: ~200-300 lines of clean Python (or Node, since the CLI lives in
+Node). There are open-source examples for similar UE games (Palworld's
+`palworld-save-tools`, Conan Exiles' DB inspectors) that share the same
+underlying parser shape.
+
+---
+
+## 7. Practical caveats
+
+- **No captured tribesmen on this dump.** All 2,280 NPC humans appear to be
+  wild — `actor_owner` is empty everywhere, and no obvious "owner =
+  player-A's-Guid" cluster is visible at first glance. The `ZhuRenGuid` field
+  exists but its value for wild NPCs may be the tribe GUID, not a player's. A
+  follow-up dump from a server with confirmed captures will be needed to
+  validate the parser.
+- **Property names use Pinyin without tone marks**, sometimes truncated, and
+  occasionally embed English (`MorphName`, `Health`, `BaoGuoComponent`,
+  `BindBGCompActor`). Build the property-name dictionary by inspection, not by
+  guessing romanizations.
+- **Some properties are deeply nested** (Map of Struct of Array) — the parser
+  must support recursion, not just a flat sweep.
+- **The GUID byte order on disk** is Unreal's `FGuid` struct (four little-endian
+  uint32s, written `A-B-C-D`). The string form we extract via regex matches the
+  on-disk hex, so equality checks are byte-for-byte.
+
+---
+
+## 8. RCON path (the actual viable route)
+
+After the BLOB-parser path stalled (community has tried and largely failed; see
+the Steam discussion linked in `README.md`), we tested Soulmask's built-in
+RCON via the Bisect MCP `send_command` tool. **RCON solves the ownership-link
+problem cleanly** — Soulmask exposes commands that produce structured text
+output including ownership.
+
+### Output capture pattern
+
+`send_command` only sends; it doesn't return output. The server writes the
+response to `/WS/Saved/Logs/WS.log` as `logServerSupervise: Display: RESPONSE:
+...` lines. So the call pattern is:
+
+1. `send_command server_id="..." command="..."`
+2. Wait ~3-5 seconds
+3. `read_file file="/WS/Saved/Logs/WS.log" tail_bytes=4000`
+4. Parse the most recent `TRY RUN ADMIN COMMAND` block
+
+### IMPORTANT — corrected syntax (the saraserenity docs were wrong)
+
+The on-server `help` command (paginated; type `n` for next page) shows the
+**actual** syntax. The published Soulmask RCON guides (`saraserenity.net`,
+various wikis) have the wrong arg shape for several commands — they list
+`InOpPlayer <value>` / `InOpGuild <value>` as if `InOpPlayer` is a keyword,
+but the real syntax is purely **positional, one arg**:
+
+```
+ls  <player_account_or_pawn_uid>          # List_SameBelongingObjs
+lgo <guild_name_or_guild_uid>             # List_GuildObjs
+lcc [substring]                           # List_AllNPCClass
+lap                                       # List_AllPlayers (no args)
+lp                                        # List_OnlinePlayers (no args)
+lg                                        # List_Guilds (no args)
+```
+
+**Each `lgo` invocation paginates** with an interactive prompt:
+
+```
+=========QUERY INTERACTIVE MODE========
+|  PAGE:   1 of 2                     |
+|  Enter any number to goto that page.|
+|  Enter n to show next page.         |
+|  Enter q to exit interactive mode.  |
+=======================================
+```
+
+The Bisect MCP `send_command` tool opens a fresh RCON connection per call. The
+server still appears to remember the per-source-IP interactive state for a few
+seconds — sending `lgo <uid>` and then `n` as separate `send_command` calls
+*does* return page 2.
+
+### Confirmed-working commands (no online player needed)
+
+| Command                  | What it returns                                                              |
+| ------------------------ | ---------------------------------------------------------------------------- |
+| `lap` / `List_AllPlayers`| Steam ID, player name, guild, level, total online seconds, birth             |
+| `lg`  / `List_Guilds`    | guild name, **guild UID**, leader name                                       |
+| `lp`  / `List_OnlinePlayers` | currently-connected players                                              |
+| `dap` / `Dump_AllActorPositions` | writes `WS/Saved/ACTOR_POSI_DATA.log` (text, ~3 MB). **No ownership info** |
+| `bk <name>` / `BackupDatabase` | consistent DB snapshot in-game (alternative to stop/start for fetch)    |
+| **`lgo <guild_uid>` / `List_GuildObjs`** | **THE BIG ONE** — name + UID for every clan-owned object: tribesmen, vehicles, animals, buildings. Works for the whole guild, no online player required. |
+
+### Requires an online player
+
+`ls <steamid>` (List_SameBelongingObjs) returns `Can't find this character.`
+even when the target player has logged in via the Steam client — the lookup
+uses an in-memory pawn list that we couldn't reliably populate via the panel
+console alone.
+
+**This turned out to not matter:** `lgo <guild_uid>` on the *guild* gives us
+everything `ls` would, since all three players in this clan share captures.
+Use `lgo` and filter the result by name suffix to get per-player views (see §9
+below).
+
+---
+
+## 9. Implementation that landed (RCON-only, no `world.db` parsing required)
+
+The world.db pull from Phase 0 is still useful — we keep the MCP tool for the
+day someone writes a UE PropertyTag parser — but **the actual importer is
+RCON-only**. Steps:
+
+### Capture (~30 seconds, no game-client login needed)
+
+1. `send_command "lg"` — find the guild UID
+2. `send_command "lgo <guild_uid>"` — page 1 of clan-owned objects
+3. `send_command "n"` — page 2 (server retains interactive state per source IP for a few seconds)
+4. `read_file /WS/Saved/Logs/WS.log tail_bytes=...` — extract the
+   `RESPONSE: …` blocks for the two pages and concatenate them.
+
+### Suffix decoding (clan convention)
+
+In our test clan ("Dozenmater") the in-game name suffixes encode owner:
+
+- `<E>` → Emmy
+- `<Q>` → husband
+- (no suffix, hyphenated tribe-style name, e.g. "Belvani Bone-Broth") → third clanmate
+- (no suffix, plain name) → either a player character or non-tribesman entity
+
+This is a **convention, not enforced by the game**. The CLI exposes
+`--owner-suffix E` to filter, with sensible auto-exclusion for vehicles
+("… Boat", "… Airship"), buildings ("… -Farm"), animals ("Cat", "Donkey",
+"Boar"), and player names.
+
+### Merge into existing roster
+
+`tools/import-world-db/cli.js` consumes:
+- the `lgo` text dump
+- the user's existing `clan_backup.json`
+
+…and produces a merged `clan_backup.json` that:
+- **preserves** every existing tribesman entry's curated data (skills, talents,
+  attrs, notes, location, etc.) when its UID still appears in `lgo`
+- **adds skeletons** (`level: null`, empty skills/weapons/talents/attrs) for new
+  captures whose UID isn't yet in the roster
+- **flags renames** — by default keeps the roster's name and reports the
+  mismatch (configurable via `--rename-policy adopt-lgo`)
+- **marks missing UIDs as `is_body: true`** (configurable via `--no-mark-body`),
+  on the assumption that a tribesman missing from `lgo` either died or was
+  transferred out of the clan
+
+The output JSON drops directly into ClanManager's existing **Restore JSON**
+flow ([app.js:1313-1348](../../app.js)). No app changes required.
+
+### Validation against real data
+
+Tested on the Dozenmater clan's actual export (25 hand-curated entries):
+
+| Result | Count | Detail |
+| --- | --- | --- |
+| unchanged | 25 | every existing entry's curated data preserved |
+| added | 2 | Gerard, Boris (post-export captures) |
+| renamed | 0 | clean — Fatty Wang already matches in the user's actual JSON |
+| marked body | 0 | nobody dropped from clan since last hand-key |
+
+Final roster size: 27 (was 25, +2). Output drops into "Restore JSON" without
+errors.
+
+---
+
+## 10. Open follow-ups
+
+- **`bk <name>` / `BackupDatabase` may eliminate the stop/start step** for the
+  Phase 0 binary fetch. RCON-triggered backups should be DB-consistent without
+  downtime. Worth validating.
+- **A full UE PropertyTag parser remains the only path to high-fidelity
+  imports** (skill levels, talent ranks, attr distributions auto-filled). If
+  someone ever writes one, the field dictionary in §4 is the starting point.
+  Reference Palworld's `palworld-save-tools` for a similar parser shape.
+- **`Dump_AllActorPositions` is useful for spawn-point mapping** but doesn't
+  help with ownership.
+- **The CLI doesn't currently auto-fetch the lgo dump.** Today the user runs
+  the RCON commands via Claude+MCP and pastes the response into a text file
+  before invoking the CLI. A future enhancement: add an `--auto-fetch
+  --server-id <id> --guild <guild_uid>` mode that drives the MCP itself. Not
+  needed for the seed-and-update workflow.
+

--- a/types.js
+++ b/types.js
@@ -55,7 +55,6 @@
  * @property {string[]} groups
  * @property {string[]} tags
  * @property {string} notes
- * @property {Object} [recognition]
  */
 
 /** @typedef {"draft"|"active"|"done"|"abandoned"} PlanStatus */


### PR DESCRIPTION
## Summary

Adds a standalone Node CLI under `tools/import-world-db/` that refreshes a ClanManager roster from a live Soulmask server, plus a small data-model cleanup.

Three import paths, each handling a different subset of fields:

- **lgo merge** — paste RCON `lgo <guild_uid>` output; CLI adds new captures as blank skeletons, preserves curated fields, flags renames, and marks missing UIDs as bodies.
- **Training-log** — paste the in-game **Training ground** log; CLI bumps weapon proficiency caps and talent levels.
- **Screenshot patch** — paste `tools/import-world-db/EXTRACT_PROMPT.md` into any Claude session along with **Character → Ability** + **Proficiency** screenshots; Claude emits a JSON patch that fills in level, the 5 attrs, and skill `current` values. Talents, notes, groups, tags, location, and `is_body` are never touched.

Browser app is unchanged. Output JSONs drop directly into the existing **Restore JSON** flow ([app.js:1313](https://github.com/EmmyAllEars/soulmask-clan-manager/blob/main/app.js#L1313)). No `npm install` — Node 18+ stdlib only.

The second commit (`chore: drop unused recognition field`) removes a typedef and 25 starter-roster fields that were never read or rendered anywhere — the in-game Recognition meter changes too quickly to be worth tracking by hand.

## Validation

End-to-end on a real 25-tribesman clan (`Dozenmater`):

| Path | Result |
| --- | --- |
| `lgo` merge | +2 new captures (Gerard, Boris), 0 renames, 0 dead, 25 unchanged |
| Training log | Andaria's Blade cap 105 → 117 (matches 12 logged training events) |
| Screenshot patch | 28 changes: 22 blank `current` fields populated, 4 cap corrections (drift in manual entries), 2 attribute corrections |

## Companion change

Depends on a small enhancement to the [BisectHosting Starbase MCP](https://github.com/EmmyAllEars/BisectHosting-Starbase-MCP) — `get_file_download_url` for binary-safe file pulls (so `world.db` could be fetched if/when a UE PropertyTag parser is ever written). That's already merged ([PR #3](https://github.com/EmmyAllEars/BisectHosting-Starbase-MCP/pull/3)).

## What this PR explicitly does *not* do

- Touch `app.js`, `index.html`, or `style.css`. The importer is fully external.
- Auto-fetch the lgo dump or training log. The user (or Claude) runs the RCON commands and feeds the text in.
- Update `level`, attribute points, or skill `current` values automatically (those need the screenshot path).
- Backfill `profession`, `tribe`, `title`, `location`, `notes`, `groups`, `tags`, `talents`, or `is_body` for new captures. Skeletons land empty; user fills them via the UI.

## Test plan

- [ ] Pull a guild's `lgo` output and an existing `clan_backup.json`, run `node cli.js --lgo … --existing … --out … --owner-suffix E --dry-run`, verify the change report.
- [ ] Repeat with `--training-log` pointed at a Training-ground copy-paste; verify weapon caps bump.
- [ ] Open a fresh Claude session with `EXTRACT_PROMPT.md` + two screenshots; verify the emitted patch JSON validates and `node apply-patch.js` reports a sensible diff.
- [ ] Load the merged JSON via **Restore JSON** in ClanManager; confirm the roster renders, profile views populate, and selecting a tribesman opens cleanly with no console errors.
- [ ] Re-export from the app and confirm `recognition` is not re-emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)