### PR TITLE
docs(extract-prompt): bias toward emitting best-read for null cells

### DIFF
--- a/tools/import-world-db/EXTRACT_PROMPT.md
+++ b/tools/import-world-db/EXTRACT_PROMPT.md
@@ -89,6 +89,17 @@ The Combat Skills tab names already match ClanManager exactly. Use them as-is:
 `Spear`, `Shield`, `Dual-blade`, `Great Sword`, `Spiked Whip`, `Blade`,
 `Bow`, `Gauntlets`, `Hammer`.
 
+### Priority of fields — read this before the rules
+
+Skill `current`, weapon `current`, and the five attributes
+(Per/Agi/Phy/End/Str) are the **primary reason this workflow exists**. They
+live only in the in-game UI — the lgo and training-log import paths can't
+capture them. If a screenshot patch comes back without these populated, the
+workflow has failed, even if the diff *looks* reasonable.
+
+Caps, level, title, tribe, and profession are useful additions but
+secondary; those can also be updated via lgo or manually in the UI.
+
 ### Rules
 
 1. **Strip owner-suffix tags** (`<E>`, `<Q>`, etc.) from the name before
@@ -98,9 +109,24 @@ The Combat Skills tab names already match ClanManager exactly. Use them as-is:
    Validate the second word is one of the six professions; if not, leave
    `profession` empty and put the whole string in `title`.
 3. **Tribe**: from `<Wildwolf Tribe>`, emit just `"Wildwolf"`.
-4. **If a screenshot is unreadable** for a particular field, omit that field
-   from the patch. Don't guess. The `apply-patch.js` tool preserves existing
-   values for any field absent from the patch.
+4. **Confidence vs. completeness — emit your best read, but bias by what's
+   already in the roster.** Two cases:
+
+   - **Cell is null/empty in the existing JSON** (most skill `current` and
+     weapon `current` values, attrs on blank skeletons): emit even at
+     marginal confidence. The user has no other source for these — a
+     correctable misread beats a permanent null. Always populate every
+     visible primary-priority cell (see above) per tribesman.
+   - **Cell has an existing value you can't confirm changed**: omit. The
+     existing value is preserved; overwriting good data with a misread is
+     the real hazard.
+
+   The user runs `--dry-run` before committing to spot-check any unexpected
+   change — that's the safety net for misreads on the first case. Don't use
+   "I might be wrong" as a reason to skip a primary-priority cell when the
+   existing value is null. A patch that "looks" successful (lots of attr
+   diffs, all reads conservative) but leaves skill/weapon currents
+   permanently blank has *failed*.
 5. **Body N / "Body Two" / etc.**: ignore — that's an in-game body-slot
    indicator, not stored in ClanManager.
 6. **Multiple tribesmen**: append additional entries to the `tribesmen`


### PR DESCRIPTION
## Summary

- Rewrites Rule 4 in `EXTRACT_PROMPT.md` to distinguish "cell is null in existing JSON" (emit best read) from "cell has an existing value you can't confirm changed" (omit). The previous wording ("if unreadable, omit") was too binary and led to patches that looked successful but left skill/weapon currents permanently null.
- Adds a "Priority of fields" callout naming skill `current`, weapon `current`, and the 5 attributes as the primary reason this workflow exists — they live only in the in-game UI and have no other capture path.
- The `--dry-run` step in `apply-patch.js` is the safety net for misreads on the "emit best read" path.

Notes for future-me, basically. Surfaced after the first attempt at refreshing the full clan from screenshots produced a patch with lots of attr diffs but null skill/weapon currents on most tribesmen — needed a second pass with bias-to-inclusion to actually populate the data.

## Test plan

- [ ] Next time we refresh from screenshots, confirm the new wording produces a patch where every visible skill/weapon `current` is populated on the first pass.
- [ ] `--dry-run` still catches at least one overwrite-of-existing-value misread (the safety net the new rule relies on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)