### PR TITLE
feat(import-world-db): add preprocess-screenshots crop tool

### DIFF
--- a/tools/import-world-db/EXTRACT_PROMPT.md
+++ b/tools/import-world-db/EXTRACT_PROMPT.md
@@ -6,6 +6,15 @@ attach screenshots of one or more tribesmen's **Character → Ability** and
 `clan-screenshot-patch-v1` JSON document you save to a file and feed to
 `apply-patch.js`.
 
+> **Preprocess your screenshots first.** Run
+> `tools/import-world-db/preprocess-screenshots.js` against your raw
+> screenshot folder and attach the cropped output to the Claude session.
+> Without cropping, the small `current/cap` numbers in the Proficiency tab
+> get downsampled into ambiguous blobs and misread rates spike (1/7, 3/8,
+> 5/6 confusions on the order of one per tribesman). The README's
+> "Refreshing skills, weapons, and stats from screenshots" section
+> documents the full workflow.
+
 > **Why a separate prompt instead of embedding it in the CLI:** vision is
 > Claude's job, not Node's. Keeping the extraction in a Claude session means
 > it works in any environment with Claude available, doesn't require an API

--- a/tools/import-world-db/README.md
+++ b/tools/import-world-db/README.md
@@ -178,11 +178,25 @@ two screenshots per tribesman: their **Character → Ability** tab and
 Workflow:
 
 1. In-game, tab through your tribesmen. For each, capture both tabs.
-2. Open a fresh Claude session, paste the contents of
-   [`EXTRACT_PROMPT.md`](EXTRACT_PROMPT.md), and attach the screenshots.
-3. Claude returns a single `clan-screenshot-patch-v1` JSON document. Save it
+2. **Preprocess.** Crop out the character model and the right-side detail
+   rail so the small `current/cap` numbers survive the vision-model
+   downsample (without this, 1/7, 3/8, 5/6 confusions are routine on the
+   proficiency tab):
+
+   ```sh
+   node preprocess-screenshots.js \
+     --in  /path/to/raw/screenshots \
+     --out /path/to/cropped
+   ```
+
+   Defaults are tuned for 3456×2234 retina screenshots; pass `--abil-crop`
+   / `--prof-crop` (`W:H:X:Y`) for other resolutions. See `--help`.
+3. Open a fresh Claude session, paste the contents of
+   [`EXTRACT_PROMPT.md`](EXTRACT_PROMPT.md), and attach the **cropped**
+   screenshots.
+4. Claude returns a single `clan-screenshot-patch-v1` JSON document. Save it
    to e.g. `/tmp/patch.json`.
-4. Apply it:
+5. Apply it:
 
    ```sh
    node apply-patch.js \
@@ -191,7 +205,7 @@ Workflow:
      --out /path/to/clan_backup_patched.json
    ```
 
-5. Load the patched JSON via **Restore JSON** in ClanManager.
+6. Load the patched JSON via **Restore JSON** in ClanManager.
 
 The patch tool only touches fields the patch contains. Talents, notes,
 groups, tags, location, `is_body` — anything user-curated — is preserved.
@@ -199,6 +213,13 @@ groups, tags, location, `is_body` — anything user-curated — is preserved.
 > **Validated end-to-end on Andaria.** A single patch produced 28 changes:
 > 22 previously-blank skill / weapon `current` values populated, 4 cap
 > corrections (the manual entries had drifted), and 2 attribute corrections.
+>
+> **Why preprocessing matters** (2026-04-28 clan refresh): A single
+> Atalanta proficiency crop surfaced 8 misreads from the previous
+> full-image pass — Dual-blade 10→61, Great Sword 33→21, Cooking 118→114,
+> Armor Crafting 101→108, plus Shield/Spiked Whip values that were
+> previously omitted entirely. Skip preprocessing only if you enjoy
+> playing detective with your roster.
 
 ## Files
 
@@ -210,6 +231,7 @@ tools/import-world-db/
   parse-training-log.js  - regex parser for in-game Training ground log events
   apply-training.js      - apply parsed training deltas to a roster
   apply-patch.js         - apply a screenshot-extracted patch to a roster
+  preprocess-screenshots.js - crop screenshots to the data-bearing region (ffmpeg)
   EXTRACT_PROMPT.md      - vision prompt to paste into a Claude session for screenshot extraction
   schema.md              - what we learned about world.db, Soulmask BLOBs, and RCON
   README.md              - this file

--- a/tools/import-world-db/preprocess-screenshots.js
+++ b/tools/import-world-db/preprocess-screenshots.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// Preprocess Soulmask Character-tab screenshots before vision extraction.
+//
+// Why this exists: macOS retina screenshots are 3456×2234. When fed to a
+// vision model, the image is downsampled aggressively, and the small
+// `current/cap` numbers in the Proficiency tab (~14px tall in source)
+// collapse into ambiguous blobs — 1/7, 3/8, 5/6 confusions become routine.
+//
+// Cropping out the character model and the right-side detail rail
+// shrinks the source to the data-bearing region only. Same downsample
+// budget, but every output pixel now lands on a number worth reading.
+// Validated on the 2026-04-28 clan refresh: a single Atalanta proficiency
+// crop surfaced 8 misreads from the previous full-image pass (e.g.
+// Dual-blade 10→61, Great Sword 33→21).
+//
+// Crop bounds are tuned for 3456×2234 retina screenshots of the Character
+// → Ability and Character → Proficiency tabs at default UI zoom. If your
+// monitor resolution differs, override with --abil-crop / --prof-crop
+// (each takes "W:H:X:Y" as ffmpeg's crop filter expects).
+//
+// Workflow:
+//   1. In game, tab through tribesmen capturing Ability + Proficiency for
+//      each. Two screenshots per tribesman.
+//   2. Run this tool against the screenshot folder.
+//   3. Feed the cropped output folder to a Claude session with
+//      EXTRACT_PROMPT.md.
+//
+// Usage:
+//   node preprocess-screenshots.js \
+//     --in  "/path/to/raw/screenshots" \
+//     --out "/path/to/cropped" \
+//     [--mode alternating|ability|proficiency] \
+//     [--abil-crop W:H:X:Y] \
+//     [--prof-crop W:H:X:Y]
+//
+// Modes:
+//   alternating (default) — sorts files by filename and assumes the
+//     pattern Ability, Proficiency, Ability, Proficiency, … For Mac
+//     screenshots named `Screenshot YYYY-MM-DD at H.MM.SS PM.png` the
+//     filename sort matches capture order.
+//   ability      — every input is treated as an Ability tab.
+//   proficiency  — every input is treated as a Proficiency tab.
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const DEFAULT_ABIL_CROP = "1900:1100:1100:80";
+const DEFAULT_PROF_CROP = "1500:2050:1100:80";
+
+function parseArgs(argv) {
+  const args = {
+    in: null,
+    out: null,
+    mode: "alternating",
+    abilCrop: DEFAULT_ABIL_CROP,
+    profCrop: DEFAULT_PROF_CROP,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    switch (a) {
+      case "--in":         args.in = next(); break;
+      case "--out":        args.out = next(); break;
+      case "--mode":       args.mode = next(); break;
+      case "--abil-crop":  args.abilCrop = next(); break;
+      case "--prof-crop":  args.profCrop = next(); break;
+      case "-h": case "--help": printHelpAndExit(0);
+      default:
+        console.error(`unknown arg: ${a}`);
+        printHelpAndExit(2);
+    }
+  }
+  if (!args.in || !args.out) {
+    console.error("--in and --out are required");
+    printHelpAndExit(2);
+  }
+  if (!["alternating", "ability", "proficiency"].includes(args.mode)) {
+    console.error(`--mode must be alternating|ability|proficiency, got "${args.mode}"`);
+    process.exit(2);
+  }
+  return args;
+}
+
+function printHelpAndExit(code) {
+  console.log(`Usage: node preprocess-screenshots.js --in <dir> --out <dir> [options]
+
+Crop Soulmask Character-tab screenshots to the data-bearing region only,
+producing denser images that survive vision-model downsampling.
+
+Required:
+  --in <dir>           Source folder of .png screenshots.
+  --out <dir>          Destination folder for cropped output (created if missing).
+
+Options:
+  --mode <m>           alternating | ability | proficiency  (default: alternating)
+                       alternating: filename-sorted, A-P-A-P-... pairing.
+  --abil-crop W:H:X:Y  Override Ability-tab crop. Default: ${DEFAULT_ABIL_CROP}
+  --prof-crop W:H:X:Y  Override Proficiency-tab crop. Default: ${DEFAULT_PROF_CROP}
+                       (tuned for 3456×2234 retina screenshots)`);
+  process.exit(code);
+}
+
+function ensureFfmpeg() {
+  const r = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" });
+  if (r.error || r.status !== 0) {
+    console.error("ffmpeg is required but not found on PATH. Install via `brew install ffmpeg` (macOS).");
+    process.exit(1);
+  }
+}
+
+function listPngs(dir) {
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.toLowerCase().endsWith(".png"))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+function crop(input, output, region) {
+  const r = spawnSync(
+    "ffmpeg",
+    ["-y", "-i", input, "-vf", `crop=${region}`, "-loglevel", "error", output],
+    { stdio: ["ignore", "inherit", "inherit"] }
+  );
+  if (r.status !== 0) {
+    throw new Error(`ffmpeg failed for ${path.basename(input)}`);
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  ensureFfmpeg();
+
+  if (!fs.existsSync(args.in)) {
+    console.error(`--in does not exist: ${args.in}`);
+    process.exit(2);
+  }
+  fs.mkdirSync(args.out, { recursive: true });
+
+  const inputs = listPngs(args.in);
+  if (inputs.length === 0) {
+    console.error(`no .png files found in ${args.in}`);
+    process.exit(1);
+  }
+
+  console.error(`=== Preprocess screenshots ===`);
+  console.error(`  in:    ${args.in}  (${inputs.length} files)`);
+  console.error(`  out:   ${args.out}`);
+  console.error(`  mode:  ${args.mode}`);
+  console.error(`  abil:  crop=${args.abilCrop}`);
+  console.error(`  prof:  crop=${args.profCrop}`);
+  console.error("");
+
+  let abilCount = 0;
+  let profCount = 0;
+  for (let i = 0; i < inputs.length; i++) {
+    const src = inputs[i];
+    const base = path.basename(src);
+    let region, tabLabel;
+    if (args.mode === "ability") {
+      region = args.abilCrop;
+      tabLabel = "abil";
+    } else if (args.mode === "proficiency") {
+      region = args.profCrop;
+      tabLabel = "prof";
+    } else {
+      // alternating: even index → ability, odd → proficiency
+      if (i % 2 === 0) {
+        region = args.abilCrop;
+        tabLabel = "abil";
+      } else {
+        region = args.profCrop;
+        tabLabel = "prof";
+      }
+    }
+    const out = path.join(args.out, base.replace(/\.png$/i, `.${tabLabel}.png`));
+    try {
+      crop(src, out, region);
+      if (tabLabel === "abil") abilCount++;
+      else profCount++;
+      console.error(`  ✎ ${base}  →  ${path.basename(out)}  [${tabLabel}]`);
+    } catch (e) {
+      console.error(`  ✗ ${base}  ${e.message}`);
+    }
+  }
+
+  console.error("");
+  console.error(`  ability-cropped:    ${abilCount}`);
+  console.error(`  proficiency-cropped: ${profCount}`);
+  console.error(`\n[ok] ${args.out}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- New `tools/import-world-db/preprocess-screenshots.js` (Node + ffmpeg) crops raw 3456×2234 retina screenshots to the data-bearing region only, before they're fed to a vision model for extraction.
- Why: a single Atalanta proficiency crop on the 2026-04-28 refresh surfaced 8 misreads from the previous full-image pass (Dual-blade 10→61, Great Sword 33→21, Cooking 118→114, Armor Crafting 101→108, plus Shield/Spiked Whip values that got skipped entirely). Same downsample budget at vision time, but every output pixel now lands on a number worth reading.
- README workflow updated to insert the crop step between "capture screenshots" and "feed to Claude session". `EXTRACT_PROMPT.md` gets a callout at the top so future Claude sessions know to expect cropped input.

## Test plan

- [x] Tool runs against the 52-screenshot 2026-04-28 folder, emits 26 `.abil.png` + 26 `.prof.png` cropped files.
- [x] ffmpeg presence check fires a clean error if missing.
- [x] Default crop bounds (`1900:1100:1100:80` ability, `1500:2050:1100:80` proficiency) capture name+title+stars+attrs and full Production+Combat tables respectively.
- [x] Re-run extraction against the cropped folder and confirm misread rate drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)