### PR TITLE
fix(talents): stack Origin levels, classify Tribe-locked/Experience as Origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ The live app is at <https://emmyallears.github.io/soulmask-clan-manager/>.
 
 ---
 
+## v1.0.1 — Origin talent fixes ([#53][], [#54][])
+
+### Fixed
+
+- **Origin talents can stack at multiple levels.** Adding e.g. *Origin - Fighting*
+  at Lv II and Lv III used to silently overwrite the first instance. The Add
+  flow now dedupes by `(name, level)` for Origin talents (matching the in-game
+  model where the same Origin can coexist at different ranks) and by `name`
+  alone for everything else, so upgrading a green-icon positive from Lv II →
+  Lv III still overwrites. ([#53][])
+- **Tribe-locked and Experience talents are now classified as Origin.** All 41
+  *Tribe -* / *Outcast -* prefixed talents and *Experience - Battle-tested*
+  used to be tagged `polarity: 'positive'`, which meant they ate slots in the
+  6-positive cap and showed up as learnable from mentors. They're born-with
+  traits — only green-icon positives are teachable. Catalog distribution shifts
+  `positive` 274 → 232 and `origin` 12 → 54 on regen. ([#54][])
+- The *Talents (N/6 positive max)* header was counting all talents instead of
+  just positives, so N would have been visibly wrong after the polarity flip.
+  Now filters by polarity to match the cap-enforcement logic.
+
+[#53]: https://github.com/EmmyAllEars/soulmask-clan-manager/issues/53
+[#54]: https://github.com/EmmyAllEars/soulmask-clan-manager/issues/54
+
+---
+
 ## v1.0.0 — Full talent catalog ([#46][])
 
 The talent catalog grew from 253 to **551 entries**, covering every Preference,

--- a/app.js
+++ b/app.js
@@ -724,7 +724,7 @@ function renderProfile() {
 
   // Talents
   html += `<div class="card full-row">
-    <h3>Talents (${(t.talents||[]).length}/6 positive max)</h3>
+    <h3>Talents (${(t.talents||[]).filter(tt => state.talents.find(x => x.name === tt.name)?.polarity === 'positive').length}/6 positive max)</h3>
     <div class="talents-grid" id="talents-grid"></div>
     <div class="add-talent-row">
       <input id="talent-input" type="text" placeholder="Search talent name…" autocomplete="off">
@@ -889,8 +889,13 @@ async function onConfirmAddTalent(id) {
     }
   }
   if (!t.talents) t.talents = [];
-  // Replace existing if same name
-  const existing = t.talents.findIndex(tt => tt.name === name);
+  // Replace existing if same name. Origin talents can coexist at multiple
+  // levels (the in-game model allows this), so for those we dedupe by
+  // (name, level) instead of by name alone.
+  const isOrigin = meta.polarity === 'origin';
+  const existing = t.talents.findIndex(tt =>
+    tt.name === name && (!isOrigin || tt.level === level)
+  );
   const entry = { name, level, icon: meta.icon };
   if (existing >= 0) t.talents[existing] = entry;
   else t.talents.push(entry);

--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@
  */
 
 // === CONSTANTS ===
-const APP_VERSION = '1.0.0';
+const APP_VERSION = '1.0.1';
 const REPO_URL = 'https://github.com/EmmyAllEars/soulmask-clan-manager';
 const STORAGE_KEY = 'soulmaskClan_v1';
 const THEME_KEY = 'soulmaskClan_theme';

--- a/data/talents.json
+++ b/data/talents.json
@@ -4476,7 +4476,7 @@
     "prereq": null,
     "icon": "icon_ng_jingli_nengzhengshanzhan.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_JingLi_nengzhengshanzhan.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-700011",
     "tiers": {
       "★": {
@@ -8814,7 +8814,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_liufangzhe.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_liufangzhe.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "outcast-cold-resist-1star-420401",
     "tiers": {
       "★": {
@@ -8841,7 +8841,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_liufangzhe.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_liufangzhe.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "outcast-radiation-resist-1star-420711",
     "tiers": {
       "★": {
@@ -8868,7 +8868,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_liufangzhe.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_liufangzhe.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "outcast-scorching-heat-resist-1star-420701",
     "tiers": {
       "★": {
@@ -11904,7 +11904,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_manjiao.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_ManJiao.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-420601",
     "tiers": {
       "★": {
@@ -11931,7 +11931,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huanglang.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuangLang.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-420501",
     "tiers": {
       "★": {
@@ -11958,7 +11958,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_lizhua.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_LiZhua.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-crit-cold-resist-1star-420041",
     "tiers": {
       "★": {
@@ -11985,7 +11985,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_lizhua.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_LiZhua.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-crit-radiation-resist-1star-420101",
     "tiers": {
       "★": {
@@ -12012,7 +12012,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_lizhua.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_LiZhua.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-crit-dmg-cold-resist-1star-420031",
     "tiers": {
       "★": {
@@ -12039,7 +12039,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_lizhua.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_LiZhua.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-420151",
     "tiers": {
       "★": {
@@ -12066,7 +12066,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_lizhua.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_LiZhua.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-crit-dmg-radiation-resist-1star-420091",
     "tiers": {
       "★": {
@@ -12093,7 +12093,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_lizhua.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_LiZhua.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-420161",
     "tiers": {
       "★": {
@@ -12120,7 +12120,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huoshi.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuoShi.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-def-cold-resist-1star-420061",
     "tiers": {
       "★": {
@@ -12147,7 +12147,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huoshi.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuoShi.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-def-radiation-resist-1star-420121",
     "tiers": {
       "★": {
@@ -12174,7 +12174,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huoshi.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuoShi.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-def-scorching-heat-resist-1star-420181",
     "tiers": {
       "★": {
@@ -12201,7 +12201,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_manjiao.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_ManJiao.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-420631",
     "tiers": {
       "★": {
@@ -12228,7 +12228,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_manjiao.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_ManJiao.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-420651",
     "tiers": {
       "★": {
@@ -12255,7 +12255,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huanglang.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuangLang.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-endurance-heat-resist-1star-420521",
     "tiers": {
       "★": {
@@ -12282,7 +12282,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huanglang.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuangLang.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-endurance-radiation-resist-1star-420541",
     "tiers": {
       "★": {
@@ -12309,7 +12309,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huanglang.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuangLang.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-increased-damage-heat-resist-1star-420531",
     "tiers": {
       "★": {
@@ -12336,7 +12336,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huanglang.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuangLang.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-increased-damage-radiation-resist-1star-420551",
     "tiers": {
       "★": {
@@ -12363,7 +12363,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_manjiao.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_ManJiao.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-420611",
     "tiers": {
       "★": {
@@ -12390,7 +12390,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huanglang.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuangLang.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-420511",
     "tiers": {
       "★": {
@@ -12417,7 +12417,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_duya.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_DuYa.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-poison-cold-resist-1star-420071",
     "tiers": {
       "★": {
@@ -12444,7 +12444,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_duya.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_DuYa.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-poison-radiation-resist-1star-420141",
     "tiers": {
       "★": {
@@ -12471,7 +12471,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_duya.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_DuYa.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-poison-scorching-heat-resist-1star-420191",
     "tiers": {
       "★": {
@@ -12498,7 +12498,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_duya.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_DuYa.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-poison-dmg-immunity-cold-resist-1star-420081",
     "tiers": {
       "★": {
@@ -12525,7 +12525,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_duya.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_DuYa.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-poison-dmg-immunity-scorching-heat-resist-1star-420201",
     "tiers": {
       "★": {
@@ -12552,7 +12552,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_duya.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_DuYa.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-420021",
     "tiers": {
       "★": {
@@ -12579,7 +12579,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_duya.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_DuYa.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-420011",
     "tiers": {
       "★": {
@@ -12606,7 +12606,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_lizhua.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_LiZhua.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-400031",
     "tiers": {
       "★": {
@@ -12633,7 +12633,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huoshi.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuoShi.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-410031",
     "tiers": {
       "★": {
@@ -12660,7 +12660,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huoshi.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuoShi.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-410011",
     "tiers": {
       "★": {
@@ -12687,7 +12687,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_lizhua.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_LiZhua.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-400011",
     "tiers": {
       "★": {
@@ -12714,7 +12714,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huoshi.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuoShi.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-410021",
     "tiers": {
       "★": {
@@ -12741,7 +12741,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huoshi.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuoShi.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-resilience-cold-resist-1star-420051",
     "tiers": {
       "★": {
@@ -12768,7 +12768,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huoshi.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuoShi.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-resilience-radiation-resist-1star-420111",
     "tiers": {
       "★": {
@@ -12795,7 +12795,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_huoshi.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_HuoShi.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-resilience-scorching-heat-resist-1star-420171",
     "tiers": {
       "★": {
@@ -12822,7 +12822,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_manjiao.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_ManJiao.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-420621",
     "tiers": {
       "★": {
@@ -12849,7 +12849,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_manjiao.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_ManJiao.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "tribe-stamina-radiation-resist-1star-420641",
     "tiers": {
       "★": {
@@ -12876,7 +12876,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_xingcunzhe.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_xingcunzhe.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-100113",
     "tiers": {
       "★★": {
@@ -12895,7 +12895,7 @@
     "prereq": null,
     "icon": "icon_ng_buluo_lizhua.webp",
     "icon_url": "https://www.soulmaskdatabase.com/images/Icon_NG_BuLuo_LiZhua.png",
-    "polarity": "positive",
+    "polarity": "origin",
     "primarySlug": "talent-400021",
     "tiers": {
       "★": {

--- a/tools/generate-talents/build.mjs
+++ b/tools/generate-talents/build.mjs
@@ -90,6 +90,10 @@ function inferPolarity({ scrapeCategory, name, curatedPolarity }) {
   if (scrapeCategory === 'Origin') return 'origin';
   if (scrapeCategory === 'Title') return 'title';
   if (scrapeCategory === 'Preference' || scrapeCategory === 'Personality') return 'preference';
+  // Tribe-locked and Experience entries are born-with traits — treated as
+  // origin for polarity purposes (not counted toward the 6-positive cap and
+  // not learnable from a mentor). Only green-icon positives are teachable.
+  if (scrapeCategory === 'Tribe Exclusive' || scrapeCategory === 'Experience') return 'origin';
   // 2. Curated override (preserves the 31 hand-tagged negatives).
   if (curatedPolarity) return curatedPolarity;
   // 3. Body-defect keyword leaders.


### PR DESCRIPTION
## Summary
- **#53** — *Origin* talents can now coexist at multiple levels on the same tribesman. The Add-talent flow used to dedupe by name only, silently overwriting the first instance. Now dedupes by `(name, level)` for Origin talents and by `name` alone for everything else (so upgrading a green-icon positive from Lv II → Lv III still overwrites).
- **#54** — *Experience - Battle-tested* and the 41 *Tribe -* / *Outcast -* prefixed talents are now `polarity: 'origin'` instead of `'positive'`. They're born-with traits: not counted toward the 6-positive cap, not learnable from a mentor, render with the amber Origin border. Catalog regenerated: `positive` 274 → 232, `origin` 12 → 54.
- Bonus: the `Talents (N/6 positive max)` header was counting *all* talents, not just positives. Now filters by polarity so the displayed N matches the cap-enforcement logic.

Closes #53. Closes #54.

## Test plan
- [x] Add *Origin - Fighting* Lv II then Lv III → both pills coexist
- [x] Re-add *Origin - Fighting* Lv III → no duplicate
- [x] Add *Swift Pace* Lv II then Lv III → Lv III replaces Lv II (positive overwrite preserved)
- [x] Add *Tribe - Increased Damage & Heat Resist* to a tribesman with 6 positives → no "6 positive max" prompt
- [x] *Tribe - …* and *Experience - Battle-tested* render with amber Origin border
- [x] `getLearnTalentPool` excludes all 54 origin talents (Tribe-/Outcast-/Experience-/Origin-)
- [x] CSV `name@level` round-trip preserves both stacked Origin entries
- [x] `node build.mjs` is idempotent (re-run produces no diff against `data/talents.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)